### PR TITLE
Basic microphone on/off toggle

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -83,7 +83,7 @@ ConfigEntry ConfigFile[] =
 
     {"Threaded3D", 0, &Threaded3D, 1, NULL, 0},
 	
-	{"Microphone", 0, &Microphone, 1, NULL, 0},
+    {"Microphone", 0, &Microphone, 1, NULL, 0},
 
     {"", -1, NULL, 0, NULL, 0}
 };

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -35,6 +35,8 @@ int DirectBoot;
 
 int Threaded3D;
 
+int Microphone;
+
 typedef struct
 {
     char Name[16];
@@ -80,6 +82,8 @@ ConfigEntry ConfigFile[] =
     {"DirectBoot", 0, &DirectBoot, 1, NULL, 0},
 
     {"Threaded3D", 0, &Threaded3D, 1, NULL, 0},
+	
+	{"Microphone", 0, &Microphone, 1, NULL, 0},
 
     {"", -1, NULL, 0, NULL, 0}
 };

--- a/src/Config.h
+++ b/src/Config.h
@@ -37,6 +37,8 @@ extern int DirectBoot;
 
 extern int Threaded3D;
 
+extern int Microphone;
+
 }
 
 #endif // CONFIG_H

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include "NDS.h"
 #include "SPI.h"
+#include "Config.h"
 
 
 namespace SPI_Firmware
@@ -408,7 +409,12 @@ void Write(u8 val, u32 hold)
         {
         case 0x10: ConvResult = TouchY; break;
         case 0x50: ConvResult = TouchX; break;
-        default: ConvResult = 0xFFF; break;
+        default: 
+		if (Config::Microphone != 0)
+			ConvResult = 0xFFF; 
+		else
+			ConvResult = 0x800;
+		break;
         }
 
         if (ControlByte & 0x08)

--- a/src/wx/EmuConfig.cpp
+++ b/src/wx/EmuConfig.cpp
@@ -39,6 +39,10 @@ EmuConfigDialog::EmuConfigDialog(wxWindow* parent)
     cbThreaded3D = new wxCheckBox(this, wxID_ANY, "Threaded 3D renderer");
     vboxmain->Add(cbThreaded3D, 0, wxALL&(~wxBOTTOM), 15);
     cbThreaded3D->SetValue(Config::Threaded3D != 0);
+	
+	cbMicrophone = new wxCheckBox(this, wxID_ANY, "Auto mic");
+    vboxmain->Add(cbMicrophone, 0, wxALL&(~wxBOTTOM), 15);
+    cbMicrophone->SetValue(Config::Microphone != 0);
 
     {
         wxPanel* p = new wxPanel(this);
@@ -67,6 +71,7 @@ void EmuConfigDialog::OnOk(wxCommandEvent& event)
 {
     Config::DirectBoot = cbDirectBoot->GetValue() ? 1:0;
     Config::Threaded3D = cbThreaded3D->GetValue() ? 1:0;
+	Config::Microphone = cbMicrophone->GetValue() ? 1:0;
     Config::Save();
 
     Close();

--- a/src/wx/EmuConfig.cpp
+++ b/src/wx/EmuConfig.cpp
@@ -40,7 +40,7 @@ EmuConfigDialog::EmuConfigDialog(wxWindow* parent)
     vboxmain->Add(cbThreaded3D, 0, wxALL&(~wxBOTTOM), 15);
     cbThreaded3D->SetValue(Config::Threaded3D != 0);
 	
-    cbMicrophone = new wxCheckBox(this, wxID_ANY, "Auto mic");
+    cbMicrophone = new wxCheckBox(this, wxID_ANY, "Auto microphone input");
     vboxmain->Add(cbMicrophone, 0, wxALL&(~wxBOTTOM), 15);
     cbMicrophone->SetValue(Config::Microphone != 0);
 

--- a/src/wx/EmuConfig.cpp
+++ b/src/wx/EmuConfig.cpp
@@ -40,7 +40,7 @@ EmuConfigDialog::EmuConfigDialog(wxWindow* parent)
     vboxmain->Add(cbThreaded3D, 0, wxALL&(~wxBOTTOM), 15);
     cbThreaded3D->SetValue(Config::Threaded3D != 0);
 	
-	cbMicrophone = new wxCheckBox(this, wxID_ANY, "Auto mic");
+    cbMicrophone = new wxCheckBox(this, wxID_ANY, "Auto mic");
     vboxmain->Add(cbMicrophone, 0, wxALL&(~wxBOTTOM), 15);
     cbMicrophone->SetValue(Config::Microphone != 0);
 
@@ -71,7 +71,7 @@ void EmuConfigDialog::OnOk(wxCommandEvent& event)
 {
     Config::DirectBoot = cbDirectBoot->GetValue() ? 1:0;
     Config::Threaded3D = cbThreaded3D->GetValue() ? 1:0;
-	Config::Microphone = cbMicrophone->GetValue() ? 1:0;
+    Config::Microphone = cbMicrophone->GetValue() ? 1:0;
     Config::Save();
 
     Close();

--- a/src/wx/EmuConfig.h
+++ b/src/wx/EmuConfig.h
@@ -38,7 +38,7 @@ private:
 
     wxCheckBox* cbDirectBoot;
     wxCheckBox* cbThreaded3D;
-	wxCheckBox* cbMicrophone;
+    wxCheckBox* cbMicrophone;
 };
 
 #endif // WX_EMUCONFIG_H

--- a/src/wx/EmuConfig.h
+++ b/src/wx/EmuConfig.h
@@ -38,6 +38,7 @@ private:
 
     wxCheckBox* cbDirectBoot;
     wxCheckBox* cbThreaded3D;
+	wxCheckBox* cbMicrophone;
 };
 
 #endif // WX_EMUCONFIG_H


### PR DESCRIPTION
This is an extremely basic option that works from the emulation menu and the config file. It toggles the microphone read from 0x800 (silence) to 0xFFF (enough noise for games that need the mic to work). It's basically copied-pasted and edited from the code for the "Threaded 3D renderer" option with an if-else statement. Fixes issue #39.