### PR TITLE
Ignore all compiled .o files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 obj
 *.depend
 *.layout
+*.o


### PR DESCRIPTION
Compiling the files individually results in some built .o files. This will ignore the files through .gitignore.