### PR TITLE
Portability fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,10 @@ if (UNIX)
     LINK_LIBRARIES(${GTK3_LIBRARIES})
 
     ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
-    
-    LINK_LIBRARIES("dl")
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        LINK_LIBRARIES("dl")
+    endif ()
 endif (UNIX)
 
 find_package(SDL2 REQUIRED)

--- a/src/libui_sdl/Platform.cpp
+++ b/src/libui_sdl/Platform.cpp
@@ -32,6 +32,8 @@
 #else
 	#include <unistd.h>
 	#include <arpa/inet.h>
+	#include <netinet/in.h>
+	#include <sys/select.h>
 	#include <sys/socket.h>
 	#define socket_t    int
 	#define sockaddr_t  struct sockaddr

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -567,7 +567,11 @@ int main(int argc, char** argv)
     // http://stackoverflow.com/questions/14543333/joystick-wont-work-using-sdl
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 
-    if (SDL_Init(SDL_INIT_EVERYTHING) < 0)
+    if (SDL_Init(SDL_INIT_HAPTIC) < 0)
+    {
+        printf("SDL couldn't init rumble\n");
+    }
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0)
     {
         printf("SDL shat itself :(\n");
         return 1;


### PR DESCRIPTION
This allows melonDS to build and run on OpenBSD.

Some notes: POSIX specifies which headers define socket types and constants. On OpenBSD that caused these errors:

    /tmp/x/melonds/src/libui_sdl/Platform.cpp:156:63: error: use of undeclared
          identifier 'INADDR_ANY'
            *(u32*)&saddr.sa_data[2] = htonl(Config::SocketBindAnyAddr ? INADDR_ANY ...
                                                                         ^

    /tmp/x/melonds/src/libui_sdl/Platform.cpp:218:5: error: unknown type name
          'fd_set'
        fd_set fd;
        ^

As far as I know libdl is not defined by any standard, and is Linux-specific.

OpenBSD's SDL2 doesn't support haptic feedback, but that just means that joysticks won't rumble; they work in every other respect.

In other words, although these commits help OpenBSD, they are not as such OpenBSD-specific.