### PR TITLE
Implemented "Blow into microphone" key.

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -25,8 +25,8 @@
 namespace Config
 {
 
-int KeyMapping[12];
-int JoyMapping[12];
+int KeyMapping[13];
+int JoyMapping[13];
 
 int WindowWidth;
 int WindowHeight;
@@ -67,6 +67,7 @@ ConfigEntry ConfigFile[] =
     {"Key_L",      0, &KeyMapping[9],   42, NULL, 0},
     {"Key_X",      0, &KeyMapping[10],  17, NULL, 0},
     {"Key_Y",      0, &KeyMapping[11],  30, NULL, 0},
+    {"Key_Mic_blow", 0, &KeyMapping[12],  41, NULL, 0},
 
     {"Joy_A",      0, &JoyMapping[0],  -1, NULL, 0},
     {"Joy_B",      0, &JoyMapping[1],  -1, NULL, 0},
@@ -80,6 +81,7 @@ ConfigEntry ConfigFile[] =
     {"Joy_L",      0, &JoyMapping[9],  -1, NULL, 0},
     {"Joy_X",      0, &JoyMapping[10], -1, NULL, 0},
     {"Joy_Y",      0, &JoyMapping[11], -1, NULL, 0},
+    {"Joy_Mic_blow", 0, &JoyMapping[12], -1, NULL, 0},
 
     {"WindowWidth",  0, &WindowWidth,  256, NULL, 0},
     {"WindowHeight", 0, &WindowHeight, 384, NULL, 0},

--- a/src/Config.h
+++ b/src/Config.h
@@ -27,8 +27,8 @@ namespace Config
 void Load();
 void Save();
 
-extern int KeyMapping[12];
-extern int JoyMapping[12];
+extern int KeyMapping[13];
+extern int JoyMapping[13];
 
 extern int WindowWidth;
 extern int WindowHeight;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -108,6 +108,8 @@ u32 KeyInput;
 u16 KeyCnt;
 u16 RCnt;
 
+bool MicBlowing;
+
 bool Running;
 
 
@@ -522,6 +524,8 @@ void SetKeyMask(u32 mask)
 
     KeyInput &= 0xFFFCFC00;
     KeyInput |= key_lo | (key_hi << 16);
+
+    MicBlowing = !(mask & 0x1000);
 }
 
 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -103,6 +103,8 @@ extern u8 ARM7BIOS[0x4000];
 
 extern u8 MainRAM[0x400000];
 
+extern bool MicBlowing;
+
 bool Init();
 void DeInit();
 void Reset();

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -478,7 +478,7 @@ void Write(u8 val, u32 hold)
         {
         case 0x10: ConvResult = TouchY; break;
         case 0x50: ConvResult = TouchX; break;
-        case 0x60: ConvResult = 0x800; break; // TODO: mic
+        case 0x60: ConvResult = NDS::MicBlowing ? rand() & 0xFFF : 0x800; break; // TODO: mic
         default: ConvResult = 0xFFF; break;
         }
 

--- a/src/libui_sdl/DlgInputConfig.cpp
+++ b/src/libui_sdl/DlgInputConfig.cpp
@@ -40,11 +40,11 @@ uiWindow* win;
 uiAreaHandler areahandler;
 uiArea* keypresscatcher;
 
-int keyorder[12] = {0, 1, 10, 11, 5, 4, 6, 7, 9, 8, 3, 2};
-char keylabels[12][8] = {"A:", "B:", "Select:", "Start:", "Right:", "Left:", "Up:", "Down:", "R:", "L:", "X:", "Y:"};
+int keyorder[13] = {0, 1, 10, 11, 5, 4, 6, 7, 9, 8, 3, 2, 12};
+char keylabels[13][10] = {"A:", "B:", "Select:", "Start:", "Right:", "Left:", "Up:", "Down:", "R:", "L:", "X:", "Y:", "Mic blow:"};
 
-int keymap[12];
-int joymap[12];
+int keymap[13];
+int joymap[13];
 
 int pollid;
 uiButton* pollbtn;
@@ -268,8 +268,8 @@ void OnCancel(uiButton* btn, void* blarg)
 
 void OnOk(uiButton* btn, void* blarg)
 {
-    memcpy(Config::KeyMapping, keymap, sizeof(int)*12);
-    memcpy(Config::JoyMapping, joymap, sizeof(int)*12);
+    memcpy(Config::KeyMapping, keymap, sizeof(int)*13);
+    memcpy(Config::JoyMapping, joymap, sizeof(int)*13);
 
     Config::Save();
 
@@ -280,8 +280,8 @@ void Open()
 {
     pollid = -1;
 
-    memcpy(keymap, Config::KeyMapping, sizeof(int)*12);
-    memcpy(joymap, Config::JoyMapping, sizeof(int)*12);
+    memcpy(keymap, Config::KeyMapping, sizeof(int)*13);
+    memcpy(joymap, Config::JoyMapping, sizeof(int)*13);
 
     win = uiNewWindow("Input config - melonDS", 600, 400, 0, 0);
     uiWindowSetMargined(win, 1);
@@ -312,7 +312,7 @@ void Open()
         
         const int width = 120;
 
-        for (int i = 0; i < 12; i++)
+        for (int i = 0; i < 13; i++)
         {
             int j = keyorder[i];
 
@@ -335,7 +335,7 @@ void Open()
         uiGrid* b_joy = uiNewGrid();
         uiGroupSetChild(g_joy, uiControl(b_joy));
 
-        for (int i = 0; i < 12; i++)
+        for (int i = 0; i < 13; i++)
         {
             int j = keyorder[i];
 

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -134,7 +134,7 @@ int EmuThreadFunc(void* burp)
         SDL_PauseAudioDevice(audio, 0);
     }
 
-    KeyInputMask = 0xFFF;
+    KeyInputMask = 0x1FFF;
 
     // TODO: support more joysticks
     if (SDL_NumJoysticks() > 0)
@@ -158,7 +158,7 @@ int EmuThreadFunc(void* burp)
 
             // poll input
             u32 keymask = KeyInputMask;
-            u32 joymask = 0xFFF;
+            u32 joymask = 0x1FFF;
             if (Joystick)
             {
                 SDL_JoystickUpdate();
@@ -406,13 +406,13 @@ int OnAreaKeyEvent(uiAreaHandler* handler, uiArea* area, uiAreaKeyEvent* evt)
 
     if (evt->Up)
     {
-        for (int i = 0; i < 12; i++)
+        for (int i = 0; i < 13; i++)
             if (evt->Scancode == Config::KeyMapping[i])
                 KeyInputMask |= (1<<i);
     }
     else if (!evt->Repeat)
     {
-        for (int i = 0; i < 12; i++)
+        for (int i = 0; i < 13; i++)
             if (evt->Scancode == Config::KeyMapping[i])
                 KeyInputMask &= ~(1<<i);
 


### PR DESCRIPTION
Mic reads max. volume white noise while that key is held down.
Should work for games that just require you to blow into microphone.

Handled the same as all other 12 keys up until `NDS::SetKeyMask()`, where it sets `NDS::MicBlowing` flag, which overrides values read from mic (0x800 as of now) with random noise (values 0x000 to 0xFFF) when set.

Only tested with "Phoenix Wright - Ace Attorney" (blowing on fingerprinting powder).