### PR TITLE
Fix build on linux, enable build directory support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,12 @@ if (UNIX)
     ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
     
     add_custom_command(OUTPUT melon_grc.c 
-        COMMAND glib-compile-resources --generate-source melon_grc.xml
-        COMMAND glib-compile-resources --generate-header melon_grc.xml)
+        COMMAND glib-compile-resources --sourcedir="${CMAKE_CURRENT_SOURCE_DIR}"
+                --target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
+                --generate-source "${CMAKE_CURRENT_SOURCE_DIR}/melon_grc.xml"
+        COMMAND glib-compile-resources --sourcedir="${CMAKE_CURRENT_SOURCE_DIR}"
+                --target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.h"
+                --generate-header "${CMAKE_CURRENT_SOURCE_DIR}/melon_grc.xml")
 
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         LINK_LIBRARIES("dl")

--- a/src/WifiAP.cpp
+++ b/src/WifiAP.cpp
@@ -23,6 +23,9 @@
 #include "WifiAP.h"
 #include "Platform.h"
 
+#ifndef __WIN32__
+#include <stddef.h>
+#endif
 
 namespace WifiAP
 {

--- a/src/libui_sdl/Platform.cpp
+++ b/src/libui_sdl/Platform.cpp
@@ -38,6 +38,7 @@
 	#define socket_t    int
 	#define sockaddr_t  struct sockaddr
 	#define closesocket close
+	#define PCAP_OPENFLAG_PROMISCUOUS 1
 #endif
 
 #ifndef INVALID_SOCKET


### PR DESCRIPTION
Specifically:

- Include `stddef.h` for missing `ptrdiff_t`
- Define `PCAP_OPENFLAG_PROMISCUOUS` if not using WinPcap because it seems to be
  a WinPcap extension
- Make use of `CMAKE_CURRENT_{SOURCE,BINARY}_DIR` to enable building under a
  directory other than root of the project

Resolves #221 