### PR TITLE
Load bios, firmware and melonDS.ini from exe, ~/.config/melonds or AppData

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -23,7 +23,8 @@
 
 namespace Config
 {
-
+FILE* GetConfigFile(const char* fileName, const char* permissions);
+bool HasConfigFile(const char* fileName);
 void Load();
 void Save();
 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "Config.h"
 #include "NDS.h"
 #include "ARM.h"
 #include "CP15.h"
@@ -244,7 +245,7 @@ void Reset()
     FILE* f;
     u32 i;
 
-    f = fopen("bios9.bin", "rb");
+    f = Config::GetConfigFile("bios9.bin", "rb");
     if (!f)
     {
         printf("ARM9 BIOS not found\n");
@@ -261,7 +262,7 @@ void Reset()
         fclose(f);
     }
 
-    f = fopen("bios7.bin", "rb");
+    f = Config::GetConfigFile("bios7.bin", "rb");
     if (!f)
     {
         printf("ARM7 BIOS not found\n");

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include "Config.h"
 #include "NDS.h"
 #include "SPI.h"
 
@@ -88,7 +89,7 @@ void Reset()
     if (Firmware) delete[] Firmware;
     Firmware = NULL;
 
-    FILE* f = fopen("firmware.bin", "rb");
+    FILE* f = Config::GetConfigFile("firmware.bin", "rb");
     if (!f)
     {
         printf("firmware.bin not found\n");
@@ -128,7 +129,7 @@ void Reset()
 
     // take a backup
     char* firmbkp = "firmware.bin.bak";
-    f = fopen(firmbkp, "rb");
+    f = Config::GetConfigFile(firmbkp, "rb");
     if (f) fclose(f);
     else
     {
@@ -307,7 +308,7 @@ void Write(u8 val, u32 hold)
 
     if (!hold && (CurCmd == 0x02 || CurCmd == 0x0A))
     {
-        FILE* f = fopen("firmware.bin", "r+b");
+        FILE* f = Config::GetConfigFile("firmware.bin", "r+b");
         if (f)
         {
             u32 cutoff = 0x7FA00 & FirmwareMask;

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -35,6 +35,7 @@
 #include "../SPU.h"
 #include "../Wifi.h"
 #include "../Platform.h"
+#include "../Config.h"
 
 
 const int kScreenRot[4] = {0, 1, 2, 3};
@@ -1047,7 +1048,7 @@ int main(int argc, char** argv)
 
     Config::Load();
 
-    if (!_fileexists("bios7.bin") || !_fileexists("bios9.bin") || !_fileexists("firmware.bin"))
+    if (!Config::HasConfigFile("bios7.bin") || !Config::HasConfigFile("bios9.bin") || !Config::HasConfigFile("firmware.bin"))
     {
         uiMsgBoxError(
             NULL,


### PR DESCRIPTION
Fixes #201 
Windows side is untested, as I'm on linux.
Currently the portable file loading mode is prioritized.