### PR TITLE
Add searching for SDL2 via pkg-config, fixes build on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,10 @@ elseif (WIN32)
 endif (UNIX)
 
 find_package(SDL2 REQUIRED)
+# If cmake couldn't find sdl2 libs and includes, then find them using pkg config
+if (UNIX AND NOT DEFINED SDL2_INCLUDE_DIR AND NOT DEFINED SDL2_LIBRARIES)
+    PKG_CHECK_MODULES(SDL2 REQUIRED sdl2)
+endif()
 include_directories(${SDL2_INCLUDE_DIR})
 link_libraries(${SDL2_LIBRARIES})
 


### PR DESCRIPTION
For some strange reason melonDS stopped building on Arch Linux for me, with SDL2 undefined reference errors.