### PR TITLE
Add manifest for building as a flatpak

### DIFF
--- a/flatpak/net.kuribo64.melonds.desktop
+++ b/flatpak/net.kuribo64.melonds.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=melonDS
+Comment=Nintendo DS emulator
+Exec=melonDS
+Type=Application
+Categories=Game;
+Terminal=false
+Icon=net.kuribo64.melonds

--- a/flatpak/net.kuribo64.melonds.yml
+++ b/flatpak/net.kuribo64.melonds.yml
@@ -1,0 +1,31 @@
+---
+app-id: net.kuribo64.melonds
+runtime: org.freedesktop.Platform
+runtime-version: '18.08'
+sdk: org.freedesktop.Sdk
+command: melonDS
+finish-args:
+  - "--share=ipc"
+  - "--socket=x11"
+  - "--socket=pulseaudio"
+  - "--share=network"
+  - "--device=all"
+  - "--filesystem=home"
+modules:
+  - name: libpcap
+    sources:
+      - type: archive
+        url: http://www.tcpdump.org/release/libpcap-1.9.0.tar.gz
+        sha256: 2edb88808e5913fdaa8e9c1fcaf272e19b2485338742b5074b9fe44d68f37019
+
+  - name: melonds
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/StapleButter/melonDS.git
+        commit: d4d4965b2fffc69958685a25a9d9fc0c78b54567
+      - type: file
+        path: net.kuribo64.melonds.desktop
+    post-install:
+      - "desktop-file-install --dir=/app/share/applications net.kuribo64.melonds.desktop"
+      - "install -D icon/melon_256x256.png /app/share/icons/hicolor/256x256/apps/net.kuribo64.melonds.png"


### PR DESCRIPTION
It's a bit rough but it includes a desktop file and everything needed 
for the emulator to run.
It enables pulseaudio for sound, network for wifi emulation, device=all 
for gamepad support and filesystem=home to enable the emulator to write 
the save files to the same folder as the rom.

Because melonds uses sdl2 and gtk3, it should run on wayland, but I'm 
not including the socket because I haven't personally tested it to work.