### PR TITLE
Use workaround for GCC incompatibilities with MSVC aggregate returns

### DIFF
--- a/src/libui_sdl/libui/windows/winapi.hpp
+++ b/src/libui_sdl/libui/windows/winapi.hpp
@@ -31,6 +31,10 @@
 #include <uxtheme.h>
 #include <windowsx.h>
 #include <shobjidl.h>
+// workaround for MinGW builds -> https://stackoverflow.com/questions/27888109/rendertarget-getsize-not-working
+#ifdef __MINGW32__
+#define WIDL_EXPLICIT_AGGREGATE_RETURNS
+#endif
 #include <d2d1.h>
 #include <d2d1helper.h>
 #include <dwrite.h>


### PR DESCRIPTION
Fixes crash on MinGW builds when ID2D1RenderTarget::GetSize() is called