### PR TITLE
Fixed checking for build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(CMAKE_BUILD_TYPE EQUAL Debug)
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
 set(CMAKE_CXX_FLAGS "-g")
-endif()
-if(CMAKE_BUILD_TYPE EQUAL Release)
+elseif(CMAKE_BUILD_TYPE STREQUAL Release)
 set(CMAKE_CXX_FLAGS "-O3 -flto")
 endif()
 


### PR DESCRIPTION
Hello,

I may be wrong but on my machine with cmake 3.13.2 the CMakeList did not recognize -DCMAKE_BUILD_TYPE=Debug and it seems to be because EQUAL is for numbers and STREQUAL is for strings.

I also refactored it into an elseif, because it looked weird to me but I can undo that of course if not to your taste.