### PR TITLE
Add instructions to build for Windows on ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ If everything went well, melonDS should now be in the `build` folder.
    ```
 If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
 
+#### Static builds (without DLLs, standalone executable)
+5. Install dependencies: `pacman -S mingw-w64-clang-aarch64-{cmake,SDL2,toolchain,qt5-static,qt5-tools,libslirp,libarchive}`
+6. Compile:
+   ```bash
+   cmake -B build -DBUILD_STATIC=ON -DCMAKE_PREFIX_PATH=/clangarm64/qt5-static
+   cmake --build build
+   ```
+If everything went well, melonDS should now be in the `build` folder.
+
 ### macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)
 2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libslirp libarchive`

--- a/README.md
+++ b/README.md
@@ -108,15 +108,6 @@ If everything went well, melonDS should now be in the `build` folder.
    ```
 If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
 
-#### Static builds (without DLLs, standalone executable)
-5. Install dependencies: `pacman -S mingw-w64-clang-aarch64-{cmake,SDL2,toolchain,qt5-static,qt5-tools,libslirp,libarchive}`
-6. Compile:
-   ```bash
-   cmake -B build -DBUILD_STATIC=ON -DCMAKE_PREFIX_PATH=/clangarm64/qt5-static
-   cmake --build build
-   ```
-If everything went well, melonDS should now be in the `build` folder.
-
 ### macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)
 2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libslirp libarchive`

--- a/README.md
+++ b/README.md
@@ -84,6 +84,39 @@ If everything went well, melonDS and the libraries it needs should now be in the
    ```
 If everything went well, melonDS should now be in the `build` folder.
 
+### Windows on ARM
+1. Install [MSYS2](https://www.msys2.org/)
+2. Open the **MSYS2 MinGW 64-bit** terminal and set it up according to [this page](https://www.msys2.org/wiki/arm64/). (ARM64 Support)
+3. Update the packages using `pacman -Syu` and reopen the terminal if it asks you to
+4. Install git to clone the repository
+   ```bash
+   pacman -S git
+   ```
+5. Download the melonDS repository and prepare:
+   ```bash
+   git clone https://github.com/melonDS-emu/melonDS
+   cd melonDS
+   ```
+#### Dynamic builds (with DLLs)
+5. Install dependencies: `pacman -S mingw-w64-clang-aarch64-{cmake,SDL2,toolchain,qt5-base,qt5-tools,qt5-svg,qt5-multimedia,libslirp,libarchive}`
+6. Compile:
+   ```bash
+   cmake -B build
+   cmake --build build
+   cd build
+   ../tools/msys-dist.sh
+   ```
+If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
+
+#### Static builds (without DLLs, standalone executable)
+5. Install dependencies: `pacman -S mingw-w64-clang-aarch64-{cmake,SDL2,toolchain,qt5-static,qt5-tools,libslirp,libarchive}`
+6. Compile:
+   ```bash
+   cmake -B build -DBUILD_STATIC=ON -DCMAKE_PREFIX_PATH=/clangarm64/qt5-static
+   cmake --build build
+   ```
+If everything went well, melonDS should now be in the `build` folder.
+
 ### macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)
 2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libslirp libarchive`

--- a/tools/msys-dist.sh
+++ b/tools/msys-dist.sh
@@ -6,8 +6,8 @@ if [[ ! -x melonDS.exe ]]; then
 fi
 
 mkdir -p dist
-
-for lib in $(ldd melonDS.exe | grep mingw | sed "s/.*=> //" | sed "s/(.*)//"); do
+tool=$(gcc -v 2>&1 | head -1 | awk '{print $1}')
+for lib in $(ldd melonDS.exe | grep $tool | sed "s/.*=> //" | sed "s/(.*)//"); do
 	cp "${lib}" dist
 done
 


### PR DESCRIPTION
For those interested in running melonDS on their Surface Pro X/9 5G, necessary dependencies are now available on MSYS2 clangarm64 repo.