### PR TITLE
Reset the JIT when loading savestate

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -713,15 +713,11 @@ bool NDS::DoSavestate(Savestate* file)
 
         SPU.SetPowerCnt(PowerControl7 & 0x0001);
         Wifi.SetPowerCnt(PowerControl7 & 0x0002);
-    }
 
 #ifdef JIT_ENABLED
-    if (!file->Saving)
-    {
-        JIT.ResetBlockCache();
-        JIT.Memory.Reset();
-    }
+        JIT.Reset();
 #endif
+    }
 
     file->Finish();
 


### PR DESCRIPTION
The effect of this change is simply to call JitEnableWrite(), which is necessary on apple silicon