### PR TITLE
Fix XML information in GdbCmds.cpp and add support for the 'vCont;' command.

### DIFF
--- a/src/debug/GdbCmds.cpp
+++ b/src/debug/GdbCmds.cpp
@@ -46,7 +46,7 @@ const char* TARGET_INFO_ARM9 = "cputype:12;cpusubtype:7;triple:arm-none-eabi;ost
 	"<reg name=\"r11\" bitsize=\"32\" type=\"uint32\"/>" \
 	"<reg name=\"r12\" bitsize=\"32\" type=\"uint32\"/>" \
 	"<reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>" \
-	"<reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>" \
+	"<reg name=\"lr\" bitsize=\"32\"/>" \
 	"<reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>" \
 	/* 16 regs */ \
 

--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -166,6 +166,7 @@ SubcmdHandler GdbStub::Handlers_v[] = {
 	{ .MainCmd = 'v', .SubStr = "Stopped"       , .Handler = GdbStub::Handle_v_Stopped },
 	{ .MainCmd = 'v', .SubStr = "MustReplyEmpty", .Handler = GdbStub::Handle_v_MustReplyEmpty },
 	{ .MainCmd = 'v', .SubStr = "Cont?"         , .Handler = GdbStub::Handle_v_ContQuery },
+	{ .MainCmd = 'v', .SubStr = "Cont;"         , .Handler = GdbStub::Handle_v_Cont },
 	{ .MainCmd = 'v', .SubStr = "Cont"          , .Handler = GdbStub::Handle_v_Cont },
 
 	{ .MainCmd = 'v', .SubStr = NULL, .Handler = NULL }


### PR DESCRIPTION
I previously encountered some issues when trying to debug with GDB provided by IDA Pro while connecting to melonDS. I made corrections to address these issues, and after the fixes, debugging in IDA Pro works as shown in the image below. Additionally, I noticed some bugs in the GDB-related configurations in the .toml file, but I am unsure how to fix them properly.
![screenshot 2024-06-20 234217](https://github.com/melonDS-emu/melonDS/assets/7060664/39241d88-af2b-4f2b-9c53-2498397c9ab8)
