### PR TITLE
ci: don't double zip mac .app

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -78,12 +78,13 @@ jobs:
           cp -a arm64/melonDS.app melonDS.app
           cp melonDS melonDS.app/Contents/MacOS/melonDS
           codesign -s - --deep melonDS.app
-          zip -r -y macOS-universal.zip melonDS.app
+          mkdir macOS-universal
+          mv melonDS.app macOS-universal
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macOS-universal
-          path: macOS-universal.zip
+          path: macOS-universal
 #     - name: Clean up architecture-specific artifacts
 #       uses: geekyeggo/delete-artifact@v4
 #       with:


### PR DESCRIPTION
resolves https://github.com/melonDS-emu/melonDS/issues/2232

https://github.com/actions/upload-artifact always zips whatever is put in `path` (doesn't matter if it's a file or directory or wildcard)

this gets a little complicated when dealing with `.app`s on macOS because `.app`s are just directories

this means if you just had

```yml
      - name: Upload artifact
        uses: actions/upload-artifact@v4
        with:
          name: macOS-universal
          path: melonDS.app
```

`upload-artifact` would treat `melonDS.app` as a directory and create a zip with the *contents* of the directory, so when someone unzips it they'd just get a `Contents` directory.

zipping the `.app` fixes that issue, but leads to the reported problem of double zips

this PR works around both issues by creating a new directory, moving the `.app` into that directory, and setting that directory as the `path` for the `upload-artifact` action

tested on my fork: https://github.com/briaguya-ai/melonDS/pull/1