### PR TITLE
"Hybrid ratio", new option on View menu for Hybrid screen layout

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -85,6 +85,7 @@ RangeList IntRanges =
     {"Mic.InputType", {0, micInputType_MAX-1}},
     {"Instance*.Window*.ScreenRotation", {0, screenRot_MAX-1}},
     {"Instance*.Window*.ScreenGap", {0, 500}},
+    {"Instance*.Window*.HybridRatio", {0, 960}},
     {"Instance*.Window*.ScreenLayout", {0, screenLayout_MAX-1}},
     {"Instance*.Window*.ScreenSizing", {0, screenSizing_MAX-1}},
     {"Instance*.Window*.ScreenAspectTop", {0, AspectRatiosNum-1}},

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -118,13 +118,16 @@ void ScreenPanel::loadConfig()
     auto& cfg = mainWindow->getWindowConfig();
     
     screenRotation = cfg.GetInt("ScreenRotation");
-    screenGap = cfg.GetInt("ScreenGap");
     screenLayout = cfg.GetInt("ScreenLayout");
+    screenGap = cfg.GetInt("ScreenGap");
+	hybridRatio = cfg.GetInt("HybridRatio");
     screenSwap = cfg.GetBool("ScreenSwap");
     screenSizing = cfg.GetInt("ScreenSizing");
     integerScaling = cfg.GetBool("IntegerScaling");
     screenAspectTop = cfg.GetInt("ScreenAspectTop");
     screenAspectBot = cfg.GetInt("ScreenAspectBot");
+
+	currentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : hybridRatio;
 }
 
 void ScreenPanel::setFilter(bool filter)
@@ -168,7 +171,7 @@ void ScreenPanel::setupScreenLayout()
                 static_cast<ScreenLayoutType>(screenLayout),
                 static_cast<ScreenRotation>(screenRotation),
                 static_cast<ScreenSizing>(sizing),
-                screenGap,
+                currentScreenGap,
                 integerScaling != 0,
                 screenSwap != 0,
                 aspectTop,
@@ -183,7 +186,7 @@ QSize ScreenPanel::screenGetMinSize(int factor = 1)
 {
     bool isHori = (screenRotation == screenRot_90Deg
         || screenRotation == screenRot_270Deg);
-    int gap = screenGap * factor;
+    int gap = currentScreenGap * factor;
 
     int w = 256 * factor;
     int h = 192 * factor;

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -82,11 +82,14 @@ protected:
 
     int screenRotation;
     int screenGap;
+	int hybridRatio;
     int screenLayout;
     bool screenSwap;
     int screenSizing;
     bool integerScaling;
     int screenAspectTop, screenAspectBot;
+
+	int currentScreenGap;
 
     int autoScreenSizing;
 

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -512,6 +512,24 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 connect(grpScreenGap, &QActionGroup::triggered, this, &MainWindow::onChangeScreenGap);
             }
             {
+                QMenu * submenu = menu->addMenu("Hybrid ratio");
+                grpHybridRatio = new QActionGroup(submenu);
+
+				const char *hybridRatio[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
+                const int screengap[] = {0, 192, 384, 576, 768, 960, 96, 64, 48};
+
+                for (int i = 0; i < 9; i++)
+                {
+                    int screenGapData = screengap[i];
+                    actHybridRatio[i] = submenu->addAction(QString(hybridRatio[i]));
+                    actHybridRatio[i]->setActionGroup(grpHybridRatio);
+                    actHybridRatio[i]->setData(QVariant(screenGapData));
+                    actHybridRatio[i]->setCheckable(true);
+                }
+
+                connect(grpHybridRatio, &QActionGroup::triggered, this, &MainWindow::onChangeHybridRatio);
+            }
+            {
                 QMenu * submenu = menu->addMenu("Screen layout");
                 grpScreenLayout = new QActionGroup(submenu);
 
@@ -746,6 +764,16 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             if (actScreenGap[i]->data().toInt() == screenGap)
             {
                 actScreenGap[i]->setChecked(true);
+                break;
+            }
+        }
+
+        int hybridRatio = windowCfg.GetInt("HybridRatio");
+        for (int i = 0; i < 9; i++)
+        {
+            if (actHybridRatio[i]->data() == hybridRatio)
+            {
+                actHybridRatio[i]->setChecked(true);
                 break;
             }
         }
@@ -2033,6 +2061,14 @@ void MainWindow::onChangeScreenGap(QAction* act)
 {
     int gap = act->data().toInt();
     windowCfg.SetInt("ScreenGap", gap);
+
+    emit screenLayoutChange();
+}
+
+void MainWindow::onChangeHybridRatio(QAction* act)
+{
+    int gap = act->data().toInt();
+    windowCfg.SetInt("HybridRatio", gap);
 
     emit screenLayoutChange();
 }

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -217,6 +217,7 @@ private slots:
     void onChangeScreenSize();
     void onChangeScreenRotation(QAction* act);
     void onChangeScreenGap(QAction* act);
+    void onChangeHybridRatio(QAction* act);
     void onChangeScreenLayout(QAction* act);
     void onChangeScreenSwap(bool checked);
     void onChangeScreenSizing(QAction* act);
@@ -335,6 +336,8 @@ public:
     QAction* actScreenRotation[screenRot_MAX];
     QActionGroup* grpScreenGap;
     QAction* actScreenGap[6];
+    QActionGroup* grpHybridRatio;
+    QAction* actHybridRatio[9];
     QActionGroup* grpScreenLayout;
     QAction* actScreenLayout[screenLayout_MAX];
     QAction* actScreenSwap;


### PR DESCRIPTION
## Objective

Adjust how the window works in hybrid screen layout to allow larger screen sizes for the main screen by creating a "Hybrid ratio" setting menu by extending the "Screen gap" setting, and to always display at a pixel-perfect integer scale when the "Force integer scaling" option, located in the "Screen sizing" menu, is enabled.

## Disclaimer

I will refer to the DS top screen as screen 1, the DS bottom screen as screen 2, and the larger screen in hybrid layout as the main screen. This naming convention is used consistently throughout this explanation.  
I will not cover behavior when "Force integer scaling" is disabled. I also will not consider a possible future implementation of flipped hybrid layout, as discussed in PR #1705; whoever implements that should simply mirror how the current hybrid layout works.

As reference, I reviewed how other emulators handle hybrid layout configurations. The libretro port of melonDS, melonDS DS, has a similar setting, but its screen gap only works in vertical mode. Since standalone melonDS offers more flexible hybrid layout options, I won't base this proposal on melonDS DS implementation — although it would be great to bring this to that version as well in the future.

Similarly, Bizhawk’s melonDS core has flexibility comparable to standalone melonDS, but for some reason its screen gap setting distorts the main screen, producing uneven pixels even at what should be a pixel-perfect aspect ratio. I’m not sure why, but since the Bizhawk core doesn’t run well on my machine (at least in the official release build), I’ve chosen to disregard it for now.

Lastly, some feature requests suggest increasing the hybrid layout screen ratio without using screen gaps, centering the smaller screens beside the main screen. That would require additional frontend positioning changes, and is outside the scope of this proposal. However, this PR is a step toward enabling that functionality in the future.

## Problem

Currently, hybrid layout defaults to a 2:1 ratio, where the main screen is twice the size of screens 1 and 2. These two smaller screens are positioned to the right of the main screen in vertical layout.

However, melonDS uses a unified window system. So, a 1x hybrid layout window is treated as a single 768×384 surface — equivalent to a 3:2 ratio in DS screen units.

When the "Screen gap" setting is increased, a gap is introduced between screens 1 and 2, and the main screen is scaled to align:
- its top edge with the top edge of screen 1, and  
- its bottom edge with the bottom edge of screen 2,  
while preserving its 4:3 aspect ratio.

This causes the overall screen height to grow by the gap value. Because of the unified window system, this also increases the width, stretching the main screen and breaking integer scaling.

When "Force integer scaling" is enabled, screens 1 and 2 correctly retain integer scaling. However, the main screen is scaled according to the fixed 4:3 aspect ratio and the screen gap, which causes it to render at non-integer scale values in the current implementation — even with integer scaling enabled.

## Solution

I propose removing the influence of the screen gap setting while in hybrid layout and adding a hybrid ratio setting. This new configuration would appear as a selectable list of screen ratios and can be implemented by cloning the existing "Screen gap" setting, while internally mapping each option to a predefined gap value based on DS screen units (192 pixels tall at 1x).

Specifically:
- Values ≥192 allow ratios between 3:1 and (2 + screen gap / 192):1
- Values <192 allow ratios like (2x + 1):x (e.g., 5:2, 7:3)

### Proposed ratio options:
Ratio | Screen gap | Final resolution
--- | --- | ---
2:1 | 0 | 768x384
3:1 | 192 | 1024x576
4:1 | 384 | 1280x768
5:1 | 576 | 1536x960
6:1 | 768 | 1792x1152
7:1 | 960 | 2048x1344
5:2 | 96 | 1792x960
7:3 | 64 | 2560x1344
9:4 | 48 | 3328x1728

You can test these options right now in the current build. After running the emulator once, open your `melonDS.toml` file (located in the exe folder) and manually set the `ScreenGap` value under the `[Instance.Window]` section. The value will be used regardless of what is displayed in the UI.

Since it's just a modification in the front end, I’ve only edited the code related to the emulator window. The emulator now includes a new menu under **View → Hybrid ratio**, directly below the **Screen gap** menu. As mentioned earlier, these values override the **Screen gap** setting only when the **Screen layout** is set to **Hybrid**.

Note: Due to hardware limitations (I only have a 1080p display), I could not fully test the 6:1, 7:1, 7:3, and 9:4 options on my system.