### PR TITLE
Implement Screenshot Hotkey

### DIFF
--- a/src/GPU.h
+++ b/src/GPU.h
@@ -861,6 +861,7 @@ public:
     // if the renderer uses RAM buffers, they should be 32-bit BGRA, 256x192 for each screen
     virtual bool GetFramebuffers(void** top, void** bottom) = 0;
     virtual void SwapBuffers() { BackBuffer ^= 1; }
+    virtual int  GetScaleFactor() { return Rend3D->GetScaleFactor(); };
 
     virtual bool NeedsShaderCompile() { return false; }
     virtual void ShaderCompileStep(int& current, int& count) {}

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -332,6 +332,7 @@ public:
     virtual void RenderFrame() = 0;
     virtual void FinishRendering() {}
     virtual void RestartFrame() {};
+    virtual int GetScaleFactor() const noexcept { return 1; }
 
     // return one scanline of the framebuffer, with X scroll applied
     // this is used in software renderers

--- a/src/GPU3D_Compute.h
+++ b/src/GPU3D_Compute.h
@@ -42,6 +42,7 @@ public:
     ~ComputeRenderer3D() override;
     bool Init() override;
     void Reset() override;
+    [[nodiscard]] int GetScaleFactor() const noexcept override { return ScaleFactor; }
 
     void SetRenderSettings(int scale, bool highResolutionCoordinates);
 

--- a/src/GPU3D_OpenGL.h
+++ b/src/GPU3D_OpenGL.h
@@ -40,7 +40,7 @@ public:
     void SetBetterPolygons(bool betterpolygons) noexcept;
     void SetScaleFactor(int scale) noexcept;
     [[nodiscard]] bool GetBetterPolygons() const noexcept { return BetterPolygons; }
-    [[nodiscard]] int GetScaleFactor() const noexcept { return ScaleFactor; }
+    [[nodiscard]] int GetScaleFactor() const noexcept override { return ScaleFactor; }
 
     void RenderFrame() override;
     u32* GetLine(int line) override;

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -194,6 +194,7 @@ LegacyEntry LegacyFile[] =
     {"HKJoy_GuitarGripRed",       0, "Joystick.HK_GuitarGripRed", true},
     {"HKJoy_GuitarGripYellow",    0, "Joystick.HK_GuitarGripYellow", true},
     {"HKJoy_GuitarGripBlue",      0, "Joystick.HK_GuitarGripBlue", true},
+    {"HKJoy_TakeScreenshot",      0, "Joystick.HK_TakeScreenshot", true},
 
     {"JoystickID", 0, "JoystickID", true},
 

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -56,6 +56,7 @@ enum
     HK_GuitarGripRed,
     HK_GuitarGripYellow,
     HK_GuitarGripBlue,
+    HK_TakeScreenshot,
     HK_MAX
 };
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -67,7 +67,8 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
     "HK_GuitarGripGreen",
     "HK_GuitarGripRed",
     "HK_GuitarGripYellow",
-    "HK_GuitarGripBlue"
+    "HK_GuitarGripBlue",
+    "HK_TakeScreenshot"
 };
 
 std::shared_ptr<SDL_mutex> EmuInstance::joyMutexGlobal = nullptr;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <algorithm>
 
+#include <QDateTime>
+
 #include <SDL2/SDL.h>
 
 #include "main.h"
@@ -586,14 +588,16 @@ void EmuThread::handleMessages()
                 }
                 frontBufferLock.unlock();
 
-                time_t curr_time;
-                time(&curr_time);
-                tm* curr_tm = std::localtime(&curr_time);
-                char filename[64];
-                std::strftime(filename, 64, "melonDS-%Y-%m-%d-%H%M%S", curr_tm);
+                auto curr_time = QDateTime::currentDateTime();
+                auto prefix = curr_time.toString("'melonDS'-yyyy-MM-dd-hhmmss");
 
-                std::string screenshotFile = 
-                emuInstance->getAssetPath(false, emuInstance->localCfg.GetString("ScreenshotPath"), ".png", filename);
+                std::string screenshotFile;
+                uint8_t index = 0;
+                do {
+                    std::string filename = (prefix + (index != 0 ? QString::asprintf(" (%0u)", index) : "")).toStdString();
+                    screenshotFile = emuInstance->getAssetPath(false, emuInstance->localCfg.GetString("ScreenshotPath"), ".png", filename);
+                    index++;
+                } while(Platform::FileExists(screenshotFile));
 
                 if (capture.save(screenshotFile.c_str(), "png")) {
                     emuInstance->osdAddMessage(0, "Screenshot taken: %s", screenshotFile.c_str());

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -168,6 +168,10 @@ void EmuThread::run()
         if (emuInstance->hotkeyPressed(HK_SwapScreens)) emit swapScreensToggle();
         if (emuInstance->hotkeyPressed(HK_SwapScreenEmphasis)) emit screenEmphasisToggle();
 
+        if (emuInstance->hotkeyPressed(HK_TakeScreenshot)) {
+            emuInstance->osdAddMessage(0, "Screenshot taken: %s", "some-random-file.png");
+        }
+
         if (emuStatus == emuStatus_Running || emuStatus == emuStatus_FrameStep)
         {
             if (emuStatus == emuStatus_FrameStep) emuStatus = emuStatus_Paused;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -555,20 +555,26 @@ void EmuThread::handleMessages()
 
                 assert(nds != nullptr);
 
-                auto capture = QImage(256, 192 * 2, QImage::Format_RGB32);
+                QImage capture;
 
                 frontBufferLock.lock();
+                int frontbuf = frontBuffer;
+
 #ifdef OGLRENDERER_ENABLED
                 if (nds->GPU.GetRenderer3D().Accelerated)
                 {
-                    /* Haven't figured out how to extract these frame buffers yet. */
-                    emuInstance->osdAddMessage(0, "HW Accelerated Screenshots Not Supported");
-                    frontBufferLock.unlock();
-                    break;
+                    int scaleFactor = nds->GPU.GetRenderer3D().GetScaleFactor();
+                    capture = QImage(256 * scaleFactor, (192 * 2 + 2) * scaleFactor, QImage::Format_RGB32);
+                    GLint currentBinding;
+                    glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &currentBinding); /* Is this Necessary? */
+                    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+                    nds->GPU.GetRenderer3D().BindOutputTexture(frontbuf);
+                    glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, capture.scanLine(0));
+                    glBindBuffer(GL_PIXEL_PACK_BUFFER, currentBinding); /* Is this Necessary? */
                 } else
 #endif
                 {
-                    int frontbuf = frontBuffer;
+                    capture = QImage(256, 192 * 2, QImage::Format_RGB32);
                     if (!nds->GPU.Framebuffer[frontbuf][0] || !nds->GPU.Framebuffer[frontbuf][1])
                     {
                         frontBufferLock.unlock();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -552,58 +552,52 @@ void EmuThread::handleMessages()
             break;
 
         case msg_EmuScreenshot:
-            if  (emuIsActive()) {
+            if  (emuIsActive())
+            {
                 auto nds = emuInstance->getNDS();
 
                 assert(nds != nullptr);
 
                 QImage capture;
 
-                frontBufferLock.lock();
-                int frontbuf = frontBuffer;
-
-#ifdef OGLRENDERER_ENABLED
-                if (nds->GPU.GetRenderer3D().Accelerated)
+                void* topbuf; void* bottombuf;
+                if (nds->GPU.GetFramebuffers(&topbuf, &bottombuf))
                 {
-                    int scaleFactor = nds->GPU.GetRenderer3D().GetScaleFactor();
-                    capture = QImage(256 * scaleFactor, (192 * 2 + 2) * scaleFactor, QImage::Format_RGB32);
+                    capture = QImage(256, 192 * 2, QImage::Format_RGB32);
+                    memcpy(capture.scanLine(0), topbuf, 256 * 192 * 4);
+                    memcpy(capture.scanLine(192), bottombuf, 256 * 192 * 4);
+                }
+                else
+                {
+                    GLuint texid = *(GLuint*)topbuf;
+                    int scaleFactor = nds->GPU.GetRenderer().GetScaleFactor();
+                    capture = QImage(256 * scaleFactor, (192 * 2) * scaleFactor, QImage::Format_RGB32);
                     GLint currentBinding;
                     glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &currentBinding); /* Is this Necessary? */
                     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-                    nds->GPU.GetRenderer3D().BindOutputTexture(frontbuf);
-                    glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, capture.scanLine(0));
+                    glActiveTexture(GL_TEXTURE0);
+                    glBindTexture(GL_TEXTURE_2D_ARRAY, texid);
+                    glGetTexImage(GL_TEXTURE_2D_ARRAY, 0, GL_BGRA, GL_UNSIGNED_BYTE, capture.scanLine(0));
                     glBindBuffer(GL_PIXEL_PACK_BUFFER, currentBinding); /* Is this Necessary? */
-                } else
-#endif
-                {
-                    capture = QImage(256, 192 * 2, QImage::Format_RGB32);
-                    if (!nds->GPU.Framebuffer[frontbuf][0] || !nds->GPU.Framebuffer[frontbuf][1])
-                    {
-                        frontBufferLock.unlock();
-                        return;
-                    }
-                    
-                    memcpy(capture.scanLine(0), nds->GPU.Framebuffer[frontbuf][0].get(), 256 * 192 * 4);
-                    memcpy(capture.scanLine(192), nds->GPU.Framebuffer[frontbuf][1].get(), 256 * 192 * 4);
                 }
-                frontBufferLock.unlock();
 
                 auto curr_time = QDateTime::currentDateTime();
                 auto prefix = curr_time.toString("'melonDS'-yyyy-MM-dd-hhmmss");
 
                 std::string screenshotFile;
                 uint8_t index = 0;
-                do {
+                do
+                {
                     std::string filename = (prefix + (index != 0 ? QString::asprintf(" (%0u)", index) : "")).toStdString();
                     screenshotFile = emuInstance->getAssetPath(false, emuInstance->localCfg.GetString("ScreenshotPath"), ".png", filename);
                     index++;
-                } while(Platform::FileExists(screenshotFile));
+                } 
+                while (Platform::FileExists(screenshotFile));
 
-                if (capture.save(screenshotFile.c_str(), "png")) {
+                if (capture.save(screenshotFile.c_str(), "png"))
                     emuInstance->osdAddMessage(0, "Screenshot taken: %s", screenshotFile.c_str());
-                } else {               
+                else            
                     emuInstance->osdAddMessage(0, "Failed to save: %s", screenshotFile.c_str());
-                }
             }
             break;
 

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -168,9 +168,7 @@ void EmuThread::run()
         if (emuInstance->hotkeyPressed(HK_SwapScreens)) emit swapScreensToggle();
         if (emuInstance->hotkeyPressed(HK_SwapScreenEmphasis)) emit screenEmphasisToggle();
 
-        if (emuInstance->hotkeyPressed(HK_TakeScreenshot)) {
-            emuInstance->osdAddMessage(0, "Screenshot taken: %s", "some-random-file.png");
-        }
+        if (emuInstance->hotkeyPressed(HK_TakeScreenshot)) emuScreenshot();
 
         if (emuStatus == emuStatus_Running || emuStatus == emuStatus_FrameStep)
         {
@@ -551,6 +549,54 @@ void EmuThread::handleMessages()
             emuInstance->osdAddMessage(0, "Reset");
             break;
 
+        case msg_EmuScreenshot:
+            if  (emuIsActive()) {
+                auto nds = emuInstance->getNDS();
+
+                assert(nds != nullptr);
+
+                auto capture = QImage(256, 192 * 2, QImage::Format_RGB32);
+
+                frontBufferLock.lock();
+#ifdef OGLRENDERER_ENABLED
+                if (nds->GPU.GetRenderer3D().Accelerated)
+                {
+                    /* Haven't figured out how to extract these frame buffers yet. */
+                    emuInstance->osdAddMessage(0, "HW Accelerated Screenshots Not Supported");
+                    frontBufferLock.unlock();
+                    break;
+                } else
+#endif
+                {
+                    int frontbuf = frontBuffer;
+                    if (!nds->GPU.Framebuffer[frontbuf][0] || !nds->GPU.Framebuffer[frontbuf][1])
+                    {
+                        frontBufferLock.unlock();
+                        return;
+                    }
+                    
+                    memcpy(capture.scanLine(0), nds->GPU.Framebuffer[frontbuf][0].get(), 256 * 192 * 4);
+                    memcpy(capture.scanLine(192), nds->GPU.Framebuffer[frontbuf][1].get(), 256 * 192 * 4);
+                }
+                frontBufferLock.unlock();
+
+                time_t curr_time;
+                time(&curr_time);
+                tm* curr_tm = std::localtime(&curr_time);
+                char filename[64];
+                std::strftime(filename, 64, "melonDS-%Y-%m-%d-%H%M%S", curr_tm);
+
+                std::string screenshotFile = 
+                emuInstance->getAssetPath(false, emuInstance->localCfg.GetString("ScreenshotPath"), ".png", filename);
+
+                if (capture.save(screenshotFile.c_str(), "png")) {
+                    emuInstance->osdAddMessage(0, "Screenshot taken: %s", screenshotFile.c_str());
+                } else {               
+                    emuInstance->osdAddMessage(0, "Failed to save: %s", screenshotFile.c_str());
+                }
+            }
+            break;
+
         case msg_InitGL:
             emuInstance->initOpenGL(msg.param.value<int>());
             useOpenGL = true;
@@ -752,6 +798,12 @@ void EmuThread::emuFrameStep()
 void EmuThread::emuReset()
 {
     sendMessage(msg_EmuReset);
+    waitMessage();
+}
+
+void EmuThread::emuScreenshot()
+{
+    sendMessage(msg_EmuScreenshot);
     waitMessage();
 }
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -64,6 +64,7 @@ public:
         msg_EmuStop,
         msg_EmuFrameStep,
         msg_EmuReset,
+        msg_EmuScreenshot,
 
         msg_InitGL,
         msg_DeInitGL,
@@ -112,6 +113,7 @@ public:
     void emuExit();
     void emuFrameStep();
     void emuReset();
+    void emuScreenshot();
 
     int bootROM(const QStringList& filename, QString& errorstr);
     int bootFirmware(QString& errorstr);

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -68,7 +68,8 @@ static constexpr std::initializer_list<int> hk_general =
     HK_PowerButton,
     HK_VolumeUp,
     HK_VolumeDown,
-    HK_AudioMuteToggle
+    HK_AudioMuteToggle,
+    HK_TakeScreenshot
 };
 
 static constexpr std::initializer_list<const char*> hk_general_labels =
@@ -89,7 +90,8 @@ static constexpr std::initializer_list<const char*> hk_general_labels =
     "DSi Power button",
     "DSi Volume up",
     "DSi Volume down",
-    "Toggle audio mute"
+    "Toggle audio mute",
+    "Take Screenshot"
 };
 
 static_assert(hk_general.size() == hk_general_labels.size());

--- a/src/frontend/qt_sdl/PathSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/PathSettingsDialog.cpp
@@ -49,6 +49,7 @@ PathSettingsDialog::PathSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     ui->txtSaveFilePath->setText(cfg.GetQString("SaveFilePath"));
     ui->txtSavestatePath->setText(cfg.GetQString("SavestatePath"));
     ui->txtCheatFilePath->setText(cfg.GetQString("CheatFilePath"));
+    ui->txtScreenshotsPath->setText(cfg.GetQString("ScreenshotPath"));
 
     int inst = emuInstance->getInstanceID();
     if (inst > 0)
@@ -112,6 +113,7 @@ void PathSettingsDialog::done(int r)
             cfg.SetQString("SaveFilePath", ui->txtSaveFilePath->text());
             cfg.SetQString("SavestatePath", ui->txtSavestatePath->text());
             cfg.SetQString("CheatFilePath", ui->txtCheatFilePath->text());
+            cfg.SetQString("ScreenshotPath", ui->txtScreenshotsPath->text());
 
             Config::Save();
 
@@ -173,4 +175,21 @@ void PathSettingsDialog::on_btnCheatFileBrowse_clicked()
     }
 
     ui->txtCheatFilePath->setText(dir);
+}
+
+void PathSettingsDialog::on_btnScreenshotsBrowse_clicked()
+{
+    QString dir = QFileDialog::getExistingDirectory(this,
+                                                     "Select screenshot output path...",
+                                                     emuDirectory);
+
+    if (dir.isEmpty()) return;
+    
+    if (!QTemporaryFile(dir).open())
+    {
+        QMessageBox::critical(this, "melonDS", errordialog);
+        return;
+    }
+
+    ui->txtScreenshotsPath->setText(dir);
 }

--- a/src/frontend/qt_sdl/PathSettingsDialog.h
+++ b/src/frontend/qt_sdl/PathSettingsDialog.h
@@ -61,6 +61,7 @@ private slots:
     void on_btnSaveFileBrowse_clicked();
     void on_btnSavestateBrowse_clicked();
     void on_btnCheatFileBrowse_clicked();
+    void on_btnScreenshotsBrowse_clicked();
 
 private:
     Ui::PathSettingsDialog* ui;

--- a/src/frontend/qt_sdl/PathSettingsDialog.ui
+++ b/src/frontend/qt_sdl/PathSettingsDialog.ui
@@ -35,7 +35,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="6" column="0" colspan="3">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string/>
@@ -63,7 +63,28 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Screenshots path:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="txtScreenshotsPath">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QPushButton" name="btnScreenshotsBrowse">
+     <property name="text">
+      <string>Browse...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -87,7 +108,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
+   <item row="5" column="0" colspan="3">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Leave a path blank to use the current ROM's path.</string>
@@ -117,6 +138,8 @@
   <tabstop>btnSavestateBrowse</tabstop>
   <tabstop>txtCheatFilePath</tabstop>
   <tabstop>btnCheatFileBrowse</tabstop>
+  <tabstop>txtScreenshotsPath</tabstop>
+  <tabstop>btnScreenshotsBrowse</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
At the request of my brother, I implemented a basic screenshot mechanism into MelonDS. This just registers a new hotkey you can assign which will save the current frame buffer to a file at the native resolution of the renderer when the button press is registered. I've gotten this to functional for all graphic modes, and I've tested it on both Windows and MacOS with a couple of users from a nuzlocke forum who helped verify that it works correctly.

I'm happy to make adjustments as you need to better fit the architecture of the project, though I did my best to try and match it.

The last feature that was requested which I haven't yet added is a way to customize the actual filename. My basic thought process is that I'd add a simple templating structure, (Like %... in python, mmmm-DD-YY with strftime, etc.) and a text box that the user can edit to change this format string. Biggest issue is that I couldn't figure out where I would put such a dialog without adding a whole new window, so I want to ask you where this would make sense to go.