### PR TITLE
Create OpenBSD CI using vm-actions

### DIFF
--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - master
 
+env:
+  MELONDS_GIT_BRANCH: ${{ github.ref }}
+  MELONDS_GIT_HASH: ${{ github.sha }}
+  MELONDS_BUILD_PROVIDER: GitHub Actions
+
 jobs:
   build:
     strategy:
@@ -22,11 +27,6 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.arch }}
-
-    env:
-      MELONDS_GIT_BRANCH: ${{ github.ref }}
-      MELONDS_GIT_HASH: ${{ github.sha }}
-      MELONDS_BUILD_PROVIDER: GitHub Actions
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
~~I could not figure out the BUILD info stuff.~~ I based off of the Ubuntu CI. This could be used as a template for the other CI platforms vm-actions supports such as NetBSD or FreeBSD

EDIT: added passing BUILD info env vars in. should be AOK now.