### PR TITLE
DateTimeDialog: update new time/date picker to current time/date when enabling 'Change to:' checkbox

### DIFF
--- a/src/frontend/qt_sdl/DateTimeDialog.cpp
+++ b/src/frontend/qt_sdl/DateTimeDialog.cpp
@@ -83,7 +83,12 @@ void DateTimeDialog::done(int r)
 
 void DateTimeDialog::on_chkChangeTime_clicked(bool checked)
 {
-    if (checked) ui->chkResetTime->setChecked(false);
+    if (checked)
+	{
+		ui->chkResetTime->setChecked(false);
+		ui->txtNewCustomTime->setDateTime(customTime);
+	}
+	
     ui->txtNewCustomTime->setEnabled(checked);
 }
 


### PR DESCRIPTION
Made it so that when enabling the "Change to:" checkbox in the DateTimeDialog, the datetime picker
is initialized to the current system time instead of the previous default of 01/01/2000 00:00:00. 

This makes it easier for users to tweak the date/time, for example when advancing time, without having to retype the whole date/time every time.

<img width="448" height="271" alt="DateTimeDialogue" src="https://github.com/user-attachments/assets/d0061fe1-3fb3-4b04-b27c-24de0d63f460" />
