### PR TITLE
Fix East Asian char or non ASCII char booting in windows commandline

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -407,6 +407,9 @@ int main(int argc, char** argv)
 
 #include <windows.h>
 
+// This function is needed for booting filename which contains East Asian char 
+// or non ASCII char from CommandLine in windows.
+// This function needs to be retained until an alternative solution is found.
 int CALLBACK WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR cmdline, int cmdshow)
 {
     if (AttachConsole(ATTACH_PARENT_PROCESS) && GetStdHandle(STD_OUTPUT_HANDLE))


### PR DESCRIPTION
Thie filename of rom which contains East Asian char or non ASCII char has error when booting from command lin in windows. #1556 #1689 #1690 #1959 #2493
This is an old problem which has had been solved. 
But in v1.1, this problem back again. 
This is beacuse a function in `src\frontend\qt_sdl\main.cpp` was removed.
`int CALLBACK WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR cmdline, int cmdshow)`
So I restore it and add comments to remind and prevent accidental deletion.