### PR TITLE
Write saved state to file after unpausing emulator

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -772,19 +772,12 @@ bool EmuInstance::loadState(const std::string& filename)
     return true;
 }
 
-bool EmuInstance::saveState(const std::string& filename)
+bool EmuInstance::saveState(std::string& buffer)
 {
-    Platform::FileHandle* file = Platform::OpenFile(filename, Platform::FileMode::Write);
-
-    if (file == nullptr)
-    { // If the file couldn't be opened...
-        return false;
-    }
 
     Savestate state;
     if (state.Error)
     { // If there was an error creating the state (and allocating its memory)...
-        Platform::CloseFile(file);
         return false;
     }
 
@@ -793,30 +786,10 @@ bool EmuInstance::saveState(const std::string& filename)
 
     if (state.Error)
     {
-        Platform::CloseFile(file);
         return false;
     }
 
-    if (Platform::FileWrite(state.Buffer(), state.Length(), 1, file) == 0)
-    { // Write the Savestate buffer to the file. If that fails...
-        Platform::Log(Platform::Error,
-                      "Failed to write %d-byte savestate to %s\n",
-                      state.Length(),
-                      filename.c_str()
-        );
-        Platform::CloseFile(file);
-        return false;
-    }
-
-    Platform::CloseFile(file);
-
-    if (globalCfg.GetBool("Savestate.RelocSRAM") && ndsSave)
-    {
-        std::string savefile = filename.substr(lastSep(filename)+1);
-        savefile = getAssetPath(false, localCfg.GetString("SaveFilePath"), ".sav", savefile);
-        savefile += instanceFileSuffix();
-        ndsSave->SetPath(savefile, false);
-    }
+    buffer = std::string(static_cast<char*>(state.Buffer()), state.Length());
 
     return true;
 }

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -182,7 +182,7 @@ private:
     std::string getSavestateName(int slot);
     bool savestateExists(int slot);
     bool loadState(const std::string& filename);
-    bool saveState(const std::string& filename);
+    bool saveState(std::string& buffer);
     void undoStateLoad();
     void unloadCheats();
     void loadCheats();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -625,8 +625,8 @@ void EmuThread::handleMessages()
             break;
 
         case msg_SaveState:
-            msgResult = emuInstance->saveState(msg.param.value<QString>().toStdString());
-            break;
+          msgResult = emuInstance->saveState(*msg.save_buffer);
+          break;
 
         case msg_LoadState:
             msgResult = emuInstance->loadState(msg.param.value<QString>().toStdString());
@@ -828,11 +828,10 @@ int EmuThread::insertGBAAddon(int type, QString& errorstr)
     return msgResult;
 }
 
-int EmuThread::saveState(const QString& filename)
-{
-    sendMessage({.type = msg_SaveState, .param = filename});
-    waitMessage();
-    return msgResult;
+int EmuThread::saveState(std::string &output_buffer) {
+  sendMessage({.type = msg_SaveState, .save_buffer = &output_buffer});
+  waitMessage();
+  return msgResult;
 }
 
 int EmuThread::loadState(const QString& filename)

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -90,6 +90,9 @@ public:
     {
         MessageType type;
         QVariant param;
+
+        // The save message will serialize to the pointed-to std::string.
+        std::string* save_buffer;
     };
 
     void sendMessage(Message msg);
@@ -119,7 +122,7 @@ public:
     void ejectCart(bool gba);
     int insertGBAAddon(int type, QString& errorstr);
 
-    int saveState(const QString& filename);
+    int saveState(std::string& buffer);
     int loadState(const QString& filename);
     int undoStateLoad();
 

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -25,6 +25,7 @@
 #include <optional>
 #include <vector>
 #include <string>
+#include <fstream>
 #include <algorithm>
 
 #include <QProcess>
@@ -1569,37 +1570,53 @@ void MainWindow::onEjectGBACart()
 
 void MainWindow::onSaveState()
 {
-    int slot = ((QAction*)sender())->data().toInt();
+    const int slot = ((QAction*)sender())->data().toInt();
 
-    QString filename;
-    if (slot > 0)
-    {
-        filename = QString::fromStdString(emuInstance->getSavestateName(slot));
+    std::string filename;
+    if (slot > 0) {
+        filename = emuInstance->getSavestateName(slot);
     }
-    else
-    {
+    else {
         // TODO: specific 'last directory' for savestate files?
         emuThread->emuPause();
         filename = QFileDialog::getSaveFileName(this,
                                                          "Save state",
                                                          globalCfg.GetQString("LastROMFolder"),
-                                                         "melonDS savestates (*.mln);;Any file (*.*)");
+                                                         "melonDS savestates (*.mln);;Any file (*.*)").toStdString();
         emuThread->emuUnpause();
-        if (filename.isEmpty())
-            return;
     }
 
-    if (emuThread->saveState(filename))
-    {
-        if (slot > 0) emuInstance->osdAddMessage(0, "State saved to slot %d", slot);
-        else          emuInstance->osdAddMessage(0, "State saved to file");
-
-        actLoadState[slot]->setEnabled(true);
+    if (filename.empty()) {
+        emuInstance->osdAddMessage(0xFFA0A0, "State save failed- no filename for slot");
     }
-    else
-    {
+
+    emuInstance->osdAddMessage(0, "Starting save...");
+
+    std::string save_buffer;
+
+    if (!emuThread->saveState(save_buffer)) {
         emuInstance->osdAddMessage(0xFFA0A0, "State save failed");
+        return;
     }
+
+    {
+        std::ofstream out(filename.c_str(), std::ios::trunc | std::ios::out);
+        out << save_buffer;
+    }
+
+
+    if (globalCfg.GetBool("Savestate.RelocSRAM") && emuInstance->ndsSave)
+    {
+        std::string savefile = filename.substr(EmuInstance::lastSep(filename)+1);
+        savefile = emuInstance->getAssetPath(false, localCfg.GetString("SaveFilePath"), ".sav", savefile);
+        savefile += emuInstance->instanceFileSuffix();
+        emuInstance->ndsSave->SetPath(savefile, false);
+    }
+
+    actLoadState[slot]->setEnabled(true);
+
+    if (slot > 0) emuInstance->osdAddMessage(0, "State saved to slot %d", slot);
+    else          emuInstance->osdAddMessage(0, "State saved to file");
 }
 
 void MainWindow::onLoadState()


### PR DESCRIPTION
I've set up my filesystem such that MelonDS saves to a network filesystem, which is handy for backup purposes. Unfortunately, this causes a noticeable pause while the file is (slowly) written out.

So do the file write in the qt thread instead: this way the emulator can resume ASAP.

I do see that I've violated CONTRIBUTING.md by using `std::ofstream` but... is that a big deal?