### PR TITLE
Use intrinsics to optimize bit counting operations

### DIFF
--- a/src/ARMInterpreter_LoadStore.cpp
+++ b/src/ARMInterpreter_LoadStore.cpp
@@ -400,11 +400,7 @@ void A_LDM(ARM* cpu)
 
     if (!(cpu->CurInstr & (1<<23)))
     {
-        for (int i = 0; i < 16; i++)
-        {
-            if (cpu->CurInstr & (1<<i))
-                base -= 4;
-        }
+        base -= 4 * __builtin_popcount(cpu->CurInstr & 0xFFFF);
 
         if (cpu->CurInstr & (1<<21))
         {
@@ -480,11 +476,7 @@ void A_STM(ARM* cpu)
 
     if (!(cpu->CurInstr & (1<<23)))
     {
-        for (u32 i = 0; i < 16; i++)
-        {
-            if (cpu->CurInstr & (1<<i))
-                base -= 4;
-        }
+        base -= 4 * __builtin_popcount(cpu->CurInstr & 0xFFFF);
 
         if (cpu->CurInstr & (1<<21))
             cpu->R[baseid] = base;
@@ -701,17 +693,8 @@ void T_LDR_SPREL(ARM* cpu)
 
 void T_PUSH(ARM* cpu)
 {
-    int nregs = 0;
+    int nregs = __builtin_popcount(cpu->CurInstr & 0x1FF);
     bool first = true;
-
-    for (int i = 0; i < 8; i++)
-    {
-        if (cpu->CurInstr & (1<<i))
-            nregs++;
-    }
-
-    if (cpu->CurInstr & (1<<8))
-        nregs++;
 
     u32 base = cpu->R[13];
     base -= (nregs<<2);


### PR DESCRIPTION
x64 features a "count bits" intrinsic, while on other platforms it can typically be performed faster than through a naive for loop.

This should provide a very small performance improvement; it also simplifies the code a little.