### PR TITLE
Fix: Swap Screen Emphasis hotkey not working (#2538)

### DIFF
--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2238,6 +2238,11 @@ void MainWindow::onScreenEmphasisToggled()
     {
         currentSizing = screenSizing_EmphTop;
     }
+    else
+    {
+        // For any other sizing mode, switch to EmphTop as a sensible default
+        currentSizing = screenSizing_EmphTop;
+    }
     windowCfg.SetInt("ScreenSizing", currentSizing);
 
     emit screenLayoutChange();


### PR DESCRIPTION
## Summary
Fixes issue #2538, and hotkey now works from any screen sizing mode.

## Problem
The [onScreenEmphasisToggled()](melonDS/src/frontend/qt_sdl/Window.cpp:2229:0-2248:1) function only handled toggling between 'EmphTop' and 'EmphBot' states, so if the current screen sizing was set to any other mode ([Even](melonDS/src/frontend/qt_sdl/Window.cpp:1004:0-1059:1), 'Auto', 'TopOnly', 'BotOnly'), pressing the hotkey did nothing.

## Solution
Added an 'else' clause to switch to 'EmphTop' when the current sizing is not already 'EmphTop' or 'EmphBot'. This allows users to:
1. Press the hotkey from any screen sizing mode to switch to "Emphasize Top"
2. Press again to toggle to "Emphasize Bottom"
3. Continue toggling between the two, and working as it intended

## Testing
Built and tested on macOS environment, and verified hotkey works from all screen sizing modes.