### PR TITLE
ci: add wayland support to AppImage releases

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
-          qt6-{base,base-private,multimedia}-dev libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev
+          qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev
     - name: Configure
       run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
     - name: Build
@@ -54,6 +54,8 @@ jobs:
         chmod a+x linuxdeploy-*.AppImage
     - name: Build the AppImage
       env:
+        EXTRA_PLATFORM_PLUGINS: libqwayland-egl.so;libqwayland-generic.so
+        EXTRA_QT_PLUGINS: waylandcompositor
         QMAKE: /usr/lib/qt6/bin/qmake
       run: |
         ./linuxdeploy-${{ matrix.arch.name }}.AppImage --appdir AppDir --plugin qt --output appimage


### PR DESCRIPTION
Currently, when you run melonDS with `QT_QPA_PLATFORM=wayland ./melonDS-x86_64.AppImage`, you get this error:

```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb.
```

This is because `linuxdeploy-plugin-qt` needs to explicitly configure wayland support at build time. That is what this PR does.

Reason for adding the new dependency:

`$EXTRA_PLATFORM_PLUGINS` needs the files `/usr/lib/{aarch64,x86_64}-linux-gnu/qt6/plugins/platforms/{libqwayland-egl.so,libqwayland-generic.so}`, found in the `qt6-wayland` package.

References for my implementation:
https://github.com/linuxdeploy/linuxdeploy-plugin-qt#environment-variables
[PCSX2](https://github.com/PCSX2/pcsx2/blob/edb2b37a925635150d3217cdd4bccff3de05b3f7/.github/workflows/scripts/linux/appimage-qt.sh#L111-#L112)

With this PR, this issue will eventually be closed: https://github.com/melonDS-emu/melonDS/issues/2386. In Qt 6.9, support was added for wayland clients to set their window icon using `setWindowIcon`, which in turn uses the wayland `xdg-toplevel-icon` protocol. However, AppImage is currently being built and packaged against a version lower than 6.9, due to the fact that the Ubuntu image of the GitHub Actions runner is using version 24.04 LTS, where the `qt6-wayland` package is still at version **_6.4_**! Therefore, this PR is the first step, then it is just a matter of waiting for GitHub Actions to update its system to a version that has Qt 6.9, and the icon will likely be available in wayland.
