### PR TITLE
Replace _POSIX_SOURCE with _POSIX_C_SOURCE 200809L in ffsystem.c

### DIFF
--- a/src/fatfs/ffsystem.c
+++ b/src/fatfs/ffsystem.c
@@ -3,8 +3,7 @@
 /* (C)ChaN, 2018                                                          */
 /*------------------------------------------------------------------------*/
 
-#define _POSIX_SOURCE
-#define _POSIX_THREAD_SAFE_FUNCTIONS
+#define _POSIX_C_SOURCE 200809L
 #include <time.h>
 
 #include "ff.h"


### PR DESCRIPTION
This requests a modern POSIX interface set which reflects modern platform realities. This ensures localtime_r(3) is declared on modern POSIX compliant platforms such as the *BSDs, as well as silences a "localtime_r not declared" warning.

Tested on OpenBSD/amd64 7.8-stable.