### PR TITLE
feat: add weighted screen sizing

### DIFF
--- a/src/frontend/ScreenLayout.h
+++ b/src/frontend/ScreenLayout.h
@@ -40,6 +40,7 @@ enum ScreenRotation
 enum ScreenSizing
 {
     screenSizing_Even, // both screens get same size
+    screenSizing_Weighted,
     screenSizing_EmphTop, // make top screen as big as possible, fit bottom screen in remaining space
     screenSizing_EmphBot,
     screenSizing_Auto, // not applied in SetupScreenLayout
@@ -48,6 +49,7 @@ enum ScreenSizing
     screenSizing_MAX,
 };
 
+const int ScreenWeightsNum = 3;
 const int kMaxScreenTransforms = 3;
 
 class ScreenLayout
@@ -72,6 +74,7 @@ public:
                int screenGap,
                bool integerScale,
                bool swapScreens,
+               int topWeight, int botWeight,
                float topAspect, float botAspect);
 
     // get a 2x3 transform matrix for each screen and whether it's a top or bottom screen

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -87,6 +87,8 @@ RangeList IntRanges =
     {"Instance*.Window*.ScreenGap", {0, 500}},
     {"Instance*.Window*.ScreenLayout", {0, screenLayout_MAX-1}},
     {"Instance*.Window*.ScreenSizing", {0, screenSizing_MAX-1}},
+    {"Instance*.Window*.ScreenWeightTop", {1, ScreenWeightsNum}},
+    {"Instance*.Window*.ScreenWeightBot", {1, ScreenWeightsNum}},
     {"Instance*.Window*.ScreenAspectTop", {0, AspectRatiosNum-1}},
     {"Instance*.Window*.ScreenAspectBot", {0, AspectRatiosNum-1}},
     {"MP.AudioMode", {0, 2}},

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -127,6 +127,8 @@ void ScreenPanel::loadConfig()
     screenSwap = cfg.GetBool("ScreenSwap");
     screenSizing = cfg.GetInt("ScreenSizing");
     integerScaling = cfg.GetBool("IntegerScaling");
+    screenWeightTop = cfg.GetInt("ScreenWeightTop");
+    screenWeightBot = cfg.GetInt("ScreenWeightBot");
     screenAspectTop = cfg.GetInt("ScreenAspectTop");
     screenAspectBot = cfg.GetInt("ScreenAspectBot");
 }
@@ -175,6 +177,8 @@ void ScreenPanel::setupScreenLayout()
                 screenGap,
                 integerScaling != 0,
                 screenSwap != 0,
+                screenWeightTop,
+                screenWeightBot,
                 aspectTop,
                 aspectBot);
 

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -88,6 +88,7 @@ protected:
     bool screenSwap;
     int screenSizing;
     bool integerScaling;
+    int screenWeightTop, screenWeightBot;
     int screenAspectTop, screenAspectBot;
 
     int autoScreenSizing;

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -165,6 +165,7 @@ private slots:
     void onChangeScreenLayout(QAction* act);
     void onChangeScreenSwap(bool checked);
     void onChangeScreenSizing(QAction* act);
+    void onChangeScreenWeight(QAction* act);
     void onChangeScreenAspect(QAction* act);
     void onChangeIntegerScaling(bool checked);
     void onOpenNewWindow();
@@ -286,6 +287,10 @@ public:
     QActionGroup* grpScreenSizing;
     QAction* actScreenSizing[screenSizing_MAX];
     QAction* actIntegerScaling;
+    QActionGroup* grpScreenWeightTop;
+    QAction** actScreenWeightTop;
+    QActionGroup* grpScreenWeightBot;
+    QAction** actScreenWeightBot;
     QActionGroup* grpScreenAspectTop;
     QAction** actScreenAspectTop;
     QActionGroup* grpScreenAspectBot;


### PR DESCRIPTION
This PR introduces a new weighted screen sizing option that allows users to independently select top and bottom screen weights. It integrates cleanly with the existing sizing modes and provides more layout flexibility without adding unnecessary complexity.