### PR TITLE
Start again with screens turned on

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -184,6 +184,9 @@ void DSi::Reset()
     GPU.DispStat[0] |= (1<<6);
     GPU.DispStat[1] |= (1<<6);
 
+    // On DSi the LCDs are already powered on at boot time
+    PowerControl9 = 0x0001;
+
     UpdateVRAMTimings();
 }
 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -492,7 +492,7 @@ void NDS::Reset()
 
     PostFlag9 = 0x00;
     PostFlag7 = 0x00;
-    PowerControl9 = 0x0001;
+    PowerControl9 = 0x0000;
     PowerControl7 = 0x0000;
 
     WifiWaitCnt = 0xFFFF; // temp


### PR DESCRIPTION
Reverts https://github.com/melonDS-emu/melonDS/commit/2e9434f7ba91c3c864fc005f65f407049fdda039, after hardware testing, the console does boot up with the powcnt1 register being set to 1 (tested when booting straight from gcdfirm)
<img width="511" height="529" alt="immagine" src="https://github.com/user-attachments/assets/18a26d7a-619a-4b3d-9bb9-e3250cb57d5d" />
