### PR TITLE
NWifi: add compatibility fixes for blocksds dswifi

### DIFF
--- a/src/DSi_NWifi.cpp
+++ b/src/DSi_NWifi.cpp
@@ -686,6 +686,14 @@ void DSi_NWifi::SendCMD(MMCCommand cmd, u32 param)
             }
         }
         return;
+
+    case MMCCommand::SDIO_OpCond:
+        Host->SendResponse(0x80ffff00, true);
+        return;
+    case MMCCommand::GetRCA:
+    case MMCCommand::Select:
+        Host->SendResponse(0, true);
+        return;
     }
 
     Log(LogLevel::Warn, "NWIFI: unknown CMD %d %08X\n", cmd, param);
@@ -813,6 +821,9 @@ void DSi_NWifi::BMI_Command()
             u32 arg = MB_Read32(0);
 
             Log(LogLevel::Debug, "BMI_EXECUTE %08X %08X\n", entry, arg);
+
+            // needs a response value. not checked in firmware, actual value depends on xtensa code...
+            MB_Write32(4, 0);
         }
         return;
 

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -538,7 +538,7 @@ u16 DSi_SDHost::Read(u32 addr)
 
     case 0x01C:
         {
-            u16 ret = (IRQStatus & 0x031D);
+            u16 ret = (IRQStatus & (0x031D | (Num ? 2 : 0)));
 
             if (!Num)
             {
@@ -564,6 +564,7 @@ u16 DSi_SDHost::Read(u32 addr)
     case 0x028: return SDOption;
 
     case 0x02C: return 0; // TODO
+    case 0x02E: return 0; // TODO
 
     case 0x034: return CardIRQCtl;
     case 0x036: return CardIRQStatus;

--- a/src/DSi_SD.h
+++ b/src/DSi_SD.h
@@ -43,6 +43,7 @@ enum class MMCCommand : u32
 	GetOCR = 1,
 	AllGetCID = 2,
 	GetRCA = 3,
+	SDIO_OpCond = 5,
 	Switch = 6,
 	Select = 7,
 	SetVoltage = 8,


### PR DESCRIPTION
* Implement (extremely basic versions of) CMD3, CMD5, and CMD7
* Return a value for BMI_EXECUTE, as [required](https://problemkaputt.de/gbatek-dsi-atheros-wifi-bmi-bootloader-commands.htm)
* Status0 bit1 [is used](https://codeberg.org/blocksds/dswifi/src/commit/b673a113a3/source/arm7/twl/sdio.twl.c#L275) in SDIO mode

Note: dswifi used to blast all bytes of all BMI commands to `MBOX[0xff]`, melonDS currently deals very badly with this (see [here](https://github.com/melonDS-emu/melonDS/blob/3e4ed84/src/DSi_NWifi.cpp#L497) and [here](https://github.com/melonDS-emu/melonDS/blob/3e4ed84/src/DSi_NWifi.cpp#L781)). Fixing this will require a refactor of NWifi, however. It is instead mitigated by [this PR](https://codeberg.org/blocksds/dswifi/pulls/11) to dswifi itself.