### PR TITLE
Configurable quick save/load state hotkeys with circular rotation

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -813,7 +813,7 @@ bool EmuInstance::saveState(const std::string& filename)
 
 int EmuInstance::findOldestSavestateSlot()
 {
-    for (int i = 1; i <= 8; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
         if (!savestateExists(i))
             return i;
@@ -822,7 +822,7 @@ int EmuInstance::findOldestSavestateSlot()
     int result = 1;
     auto oldestTime = std::filesystem::file_time_type::max();
 
-    for (int i = 1; i <= 8; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
         std::error_code mtimeError;
         auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);
@@ -841,7 +841,7 @@ int EmuInstance::findNewestSavestateSlot()
     int result = -1;
     auto newestTime = std::filesystem::file_time_type::min();
 
-    for (int i = 1; i <= 8; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
         std::error_code mtimeError;
         auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include <codecvt>
+#include <filesystem>
 #include <locale>
 #include <memory>
 #include <tuple>
@@ -807,6 +808,87 @@ bool EmuInstance::saveState(const std::string& filename)
 
     Platform::CloseFile(file);
 
+    return true;
+}
+
+int EmuInstance::findOldestSavestateSlot()
+{
+    for (int i = 1; i <= 8; i++)
+    {
+        if (!savestateExists(i))
+            return i;
+    }
+
+    int result = 1;
+    auto oldestTime = std::filesystem::file_time_type::max();
+
+    for (int i = 1; i <= 8; i++)
+    {
+        std::error_code mtimeError;
+        auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);
+        if (!mtimeError && mtime < oldestTime)
+        {
+            oldestTime = mtime;
+            result = i;
+        }
+    }
+
+    return result;
+}
+
+int EmuInstance::findNewestSavestateSlot()
+{
+    int result = -1;
+    auto newestTime = std::filesystem::file_time_type::min();
+
+    for (int i = 1; i <= 8; i++)
+    {
+        std::error_code mtimeError;
+        auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);
+        if (!mtimeError && mtime > newestTime)
+        {
+            newestTime = mtime;
+            result = i;
+        }
+    }
+
+    return result;
+}
+
+bool EmuInstance::quickSaveState()
+{
+    if (!nds)
+        return false;
+
+    int slot = findOldestSavestateSlot();
+    std::string filename = getSavestateName(slot);
+    if (!saveState(filename))
+        return false;
+
+    osdAddMessage(0, "State saved to slot %d", slot);
+    return true;
+}
+
+bool EmuInstance::quickLoadState()
+{
+    if (!nds)
+        return false;
+
+    int slot = findNewestSavestateSlot();
+    if (slot < 0)
+    {
+        osdAddMessage(0xFFA0A0, "No quick save states found");
+        return false;
+    }
+
+    std::string filename = getSavestateName(slot);
+    if (!loadState(filename))
+    {
+        osdAddMessage(0xFFA0A0, "Quick state load failed");
+        return false;
+    }
+
+    osdAddMessage(0, "State loaded from slot %d", slot);
     return true;
 }
 

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -824,11 +824,11 @@ int EmuInstance::findOldestSavestateSlot()
 
     for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
-        std::error_code mtimeError;
-        auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);
-        if (!mtimeError && mtime < oldestTime)
+        std::error_code timeError;
+        auto modificationTime = std::filesystem::last_write_time(getSavestateName(i), timeError);
+        if (!timeError && modificationTime < oldestTime)
         {
-            oldestTime = mtime;
+            oldestTime = modificationTime;
             result = i;
         }
     }
@@ -843,11 +843,11 @@ int EmuInstance::findNewestSavestateSlot()
 
     for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
-        std::error_code mtimeError;
-        auto mtime = std::filesystem::last_write_time(getSavestateName(i), mtimeError);
-        if (!mtimeError && mtime > newestTime)
+        std::error_code timeError;
+        auto modificationTime = std::filesystem::last_write_time(getSavestateName(i), timeError);
+        if (!timeError && modificationTime > newestTime)
         {
-            newestTime = mtime;
+            newestTime = modificationTime;
             result = i;
         }
     }

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -30,6 +30,7 @@
 #include "SaveManager.h"
 
 const int kMaxWindows = 4;
+const int kMaxSavestateSlots = 8;
 
 enum
 {

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -56,6 +56,8 @@ enum
     HK_GuitarGripRed,
     HK_GuitarGripYellow,
     HK_GuitarGripBlue,
+    HK_QuickSaveState,
+    HK_QuickLoadState,
     HK_MAX
 };
 
@@ -183,6 +185,10 @@ private:
     void initFirmwareSaveManager() noexcept;
     std::string getSavestateName(int slot);
     bool savestateExists(int slot);
+    int findOldestSavestateSlot();
+    int findNewestSavestateSlot();
+    bool quickSaveState();
+    bool quickLoadState();
     bool loadState(const std::string& filename);
     bool saveState(const std::string& filename);
     void undoStateLoad();

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -67,7 +67,9 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
     "HK_GuitarGripGreen",
     "HK_GuitarGripRed",
     "HK_GuitarGripYellow",
-    "HK_GuitarGripBlue"
+    "HK_GuitarGripBlue",
+    "HK_QuickSaveState",
+    "HK_QuickLoadState"
 };
 
 std::shared_ptr<SDL_mutex> EmuInstance::joyMutexGlobal = nullptr;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -82,6 +82,7 @@ void EmuThread::attachWindow(MainWindow* window)
     {
         connect(this, SIGNAL(windowLimitFPSChange()), window->actLimitFramerate, SLOT(trigger()));
         connect(this, SIGNAL(swapScreensToggle()), window->actScreenSwap, SLOT(trigger()));
+        connect(this, SIGNAL(windowSavestateChange()), window, SLOT(onSavestateChange()));
     }
 }
 
@@ -100,6 +101,7 @@ void EmuThread::detachWindow(MainWindow* window)
     {
         disconnect(this, SIGNAL(windowLimitFPSChange()), window->actLimitFramerate, SLOT(trigger()));
         disconnect(this, SIGNAL(swapScreensToggle()), window->actScreenSwap, SLOT(trigger()));
+        disconnect(this, SIGNAL(windowSavestateChange()), window, SLOT(onSavestateChange()));
     }
 }
 
@@ -162,6 +164,16 @@ void EmuThread::run()
         if (emuInstance->hotkeyPressed(HK_Pause)) emuTogglePause();
         if (emuInstance->hotkeyPressed(HK_Reset)) emuReset();
         if (emuInstance->hotkeyPressed(HK_FrameStep)) emuFrameStep();
+        if (emuInstance->hotkeyPressed(HK_QuickSaveState))
+        {
+            emuInstance->quickSaveState();
+            emit windowSavestateChange();
+        }
+        if (emuInstance->hotkeyPressed(HK_QuickLoadState))
+        {
+            emuInstance->quickLoadState();
+            emit windowSavestateChange();
+        }
 
         if (emuInstance->hotkeyPressed(HK_FullscreenToggle)) emit windowFullscreenToggle();
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -160,6 +160,8 @@ signals:
 
     void syncVolumeLevel();
 
+    void windowSavestateChange();
+
 private:
     void handleMessages();
 

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -68,7 +68,9 @@ static constexpr std::initializer_list<int> hk_general =
     HK_PowerButton,
     HK_VolumeUp,
     HK_VolumeDown,
-    HK_AudioMuteToggle
+    HK_AudioMuteToggle,
+    HK_QuickSaveState,
+    HK_QuickLoadState
 };
 
 static constexpr std::initializer_list<const char*> hk_general_labels =
@@ -89,7 +91,9 @@ static constexpr std::initializer_list<const char*> hk_general_labels =
     "DSi Power button",
     "DSi Volume up",
     "DSi Volume down",
-    "Toggle audio mute"
+    "Toggle audio mute",
+    "Quick save state",
+    "Quick load state"
 };
 
 static_assert(hk_general.size() == hk_general_labels.size());

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -354,7 +354,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             {
                 QMenu * submenu = menu->addMenu("Save state");
 
-                for (int i = 1; i < 9; i++)
+                for (int i = 1; i <= kMaxSavestateSlots; i++)
                 {
                     actSaveState[i] = submenu->addAction(QString("%1").arg(i));
                     actSaveState[i]->setShortcut(QKeySequence(Qt::ShiftModifier | (Qt::Key_F1 + i - 1)));
@@ -370,7 +370,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             {
                 QMenu * submenu = menu->addMenu("Load state");
 
-                for (int i = 1; i < 9; i++)
+                for (int i = 1; i <= kMaxSavestateSlots; i++)
                 {
                     actLoadState[i] = submenu->addAction(QString("%1").arg(i));
                     actLoadState[i]->setShortcut(QKeySequence(Qt::Key_F1 + i - 1));
@@ -713,7 +713,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 act->setEnabled(false);
         }
 
-        for (int i = 0; i < 9; i++)
+        for (int i = 0; i <= kMaxSavestateSlots; i++)
         {
             actSaveState[i]->setEnabled(false);
             actLoadState[i]->setEnabled(false);
@@ -2235,7 +2235,7 @@ void MainWindow::onScreenEmphasisToggled()
 
 void MainWindow::updateSavestateMenuTimestamps()
 {
-    for (int i = 1; i < 9; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
         std::string statePath = emuInstance->getSavestateName(i);
         std::error_code timeError;
@@ -2262,7 +2262,7 @@ void MainWindow::onEmuStart()
 {
     if (!hasMenu) return;
 
-    for (int i = 1; i < 9; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
     {
         actSaveState[i]->setEnabled(true);
         actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
@@ -2290,7 +2290,7 @@ void MainWindow::onEmuStop()
 {
     if (!hasMenu) return;
 
-    for (int i = 0; i < 9; i++)
+    for (int i = 0; i <= kMaxSavestateSlots; i++)
     {
         actSaveState[i]->setEnabled(false);
         actLoadState[i]->setEnabled(false);
@@ -2319,7 +2319,7 @@ void MainWindow::onSavestateChange()
 {
     if (!hasMenu) return;
 
-    for (int i = 1; i < 9; i++)
+    for (int i = 1; i <= kMaxSavestateSlots; i++)
         actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
 
     updateSavestateMenuTimestamps();

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2242,11 +2242,10 @@ void MainWindow::updateSavestateMenuTimestamps()
         auto modificationTime = std::filesystem::last_write_time(statePath, timeError);
         if (!timeError)
         {
-            auto systemTimePoint = std::chrono::time_point_cast<std::chrono::system_clock::duration>(modificationTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
-            std::time_t rawTime = std::chrono::system_clock::to_time_t(systemTimePoint);
-            char timeBuffer[64];
-            std::strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %H:%M:%S", std::localtime(&rawTime));
-            QString formattedTime = QString("   %1").arg(timeBuffer);
+            auto clockDiff = modificationTime - std::filesystem::file_time_type::clock::now();
+            auto systemTimePoint = std::chrono::time_point_cast<std::chrono::system_clock::duration>(std::chrono::system_clock::now() + clockDiff);
+            QDateTime dt = QDateTime::fromSecsSinceEpoch(std::chrono::system_clock::to_time_t(systemTimePoint));
+            QString formattedTime = QString("   %1").arg(dt.toString("yyyy-MM-dd hh:mm:ss"));
             actSaveState[i]->setText(QString("%1%2").arg(i).arg(formattedTime));
             actLoadState[i]->setText(QString("%1%2").arg(i).arg(formattedTime));
         }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include <optional>
+#include <filesystem>
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -2232,6 +2233,31 @@ void MainWindow::onScreenEmphasisToggled()
     emit screenLayoutChange();
 }
 
+void MainWindow::updateSavestateMenuTimestamps()
+{
+    for (int i = 1; i < 9; i++)
+    {
+        std::string statePath = emuInstance->getSavestateName(i);
+        std::error_code timeError;
+        auto modificationTime = std::filesystem::last_write_time(statePath, timeError);
+        if (!timeError)
+        {
+            auto systemTimePoint = std::chrono::time_point_cast<std::chrono::system_clock::duration>(modificationTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+            std::time_t rawTime = std::chrono::system_clock::to_time_t(systemTimePoint);
+            char timeBuffer[64];
+            std::strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %H:%M:%S", std::localtime(&rawTime));
+            QString formattedTime = QString("   %1").arg(timeBuffer);
+            actSaveState[i]->setText(QString("%1%2").arg(i).arg(formattedTime));
+            actLoadState[i]->setText(QString("%1%2").arg(i).arg(formattedTime));
+        }
+        else
+        {
+            actSaveState[i]->setText(QString("%1").arg(i));
+            actLoadState[i]->setText(QString("%1").arg(i));
+        }
+    }
+}
+
 void MainWindow::onEmuStart()
 {
     if (!hasMenu) return;
@@ -2241,6 +2267,9 @@ void MainWindow::onEmuStart()
         actSaveState[i]->setEnabled(true);
         actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
     }
+
+    updateSavestateMenuTimestamps();
+
     actSaveState[0]->setEnabled(true);
     actLoadState[0]->setEnabled(true);
     actUndoStateLoad->setEnabled(false);
@@ -2292,6 +2321,8 @@ void MainWindow::onSavestateChange()
 
     for (int i = 1; i < 9; i++)
         actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
+
+    updateSavestateMenuTimestamps();
 }
 
 void MainWindow::onEmuReset()

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2286,6 +2286,14 @@ void MainWindow::onEmuPause(bool pause)
     actPause->setChecked(pause);
 }
 
+void MainWindow::onSavestateChange()
+{
+    if (!hasMenu) return;
+
+    for (int i = 1; i < 9; i++)
+        actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
+}
+
 void MainWindow::onEmuReset()
 {
     if (!hasMenu) return;

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -199,6 +199,8 @@ private:
     QStringList pickROM(bool gba);
     void updateCartInserted(bool gba);
 
+    void updateSavestateMenuTimestamps();
+
     void createScreenPanel();
 
     bool lanWarning(bool host);

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -178,6 +178,7 @@ private slots:
     void onEmuStop();
     void onEmuPause(bool pause);
     void onEmuReset();
+    void onSavestateChange();
 
     void onUpdateVideoSettings(bool glchange);
 


### PR DESCRIPTION
Hi,

I want to add a capability that I think everyone would enjoy and I personally need, it's an attempt to copy the behavior of visual boy advance emulator that allows saving in a circular manner based on file modification time. 

**The main changes in this PR:**
- Configurable quick save/load hotkeys, added two new hotkeys (`HK_QuickSaveState`, `HK_QuickLoadState`)
    -  Quick save - Automatically saves to the oldest slot (circular rotation)
    - Quick load - Automatically loads the most recently saved slot
- The `windowSavestateChange` and `onSavestateChange` functions enable syncing with the file -> save/load menus, upon pressing the quick save hotkey, the menu would also be updated
    
**Kind of unrelated but very useful anyway in the context of save states:**
- The file > save/load state menus will display the modification date and time for each slot
<img width="532" height="264" alt="image" src="https://github.com/user-attachments/assets/9da67600-3c96-43b3-815a-15717921f0a5" />

I am already using this myself with a game I am playing, and it's working pretty well so far, haven't run into any issues, but you are welcome to test yourself