### PR TITLE
Fix portable mode not working when running as AppImage

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -193,6 +193,15 @@ void pathInit()
     }
 #endif
 
+#if defined(__linux__)
+    QByteArray appimageEnv = qgetenv("APPIMAGE");
+    if (!appimageEnv.isEmpty())
+    {
+        QFileInfo appimageInfo(QString::fromUtf8(appimageEnv));
+        portablepath = appimageInfo.absolutePath() + QDir::separator() + "portable";
+    }
+#endif
+
     QDir portabledir(portablepath);
     if (portabledir.exists())
     {


### PR DESCRIPTION
Hey! So here's the deal.

If you run melonDS as an AppImage, the `portable` folder you placed next to it just gets ignored. That's because Qt thinks the app is running from some random `/tmp/.mount_...` path (the internal FUSE mount point) instead of where you actually put your `.AppImage` file. So it never finds the `portable` marker.
### What this does
- Checks the `$APPIMAGE` environment variable, which the AppImage runtime sets to the real path of the file
- Uses that to look for the `portable` folder in the right place instead of the temp mount path
### What if I'm not using an AppImage?
This changes nothing for you. Completely harmless.
### How to test
1. Put a `portable` folder next to your AppImage
2. Run it
3. Check that melonDS uses it as the config directory

Cheers!