### PR TITLE
ci: use Windows SDK and Clang for Windows builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,40 +18,33 @@ env:
 jobs:
   build:
     runs-on: windows-2025
-    defaults:
-      run:
-        shell: msys2 {0}
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
     - name: Check out sources
       uses: actions/checkout@v6
-    - name: Set up MSYS2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ucrt64
-        update: true
-        pacboy: gcc:p cmake:p ninja:p make:p
     - name: Restore vcpkg cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-x86_64-mingw-${{ hashFiles('vcpkg.json') }}
-        restore-keys: vcpkg-x86_64-mingw-
+        key: vcpkg-x86_64-windows-${{ hashFiles('vcpkg.json') }}
+        restore-keys: vcpkg-x86_64-windows-
     - name: Set up vcpkg
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgJsonGlob: vcpkg.json
-    - name: Configure
-      run: cmake --preset=release-mingw-x86_64 -DMELONDS_EMBED_BUILD_INFO=ON
     - name: Build
-      run: cmake --build --preset=release-mingw-x86_64
+      uses: lukka/run-cmake@v10
+      with:
+        configurePreset: release-windows-x86_64
+        configurePresetAdditionalArgs: "['-DENABLE_DEBUG_DEPS=OFF', '-DMELONDS_EMBED_BUILD_INFO=ON']"
+        buildPreset: release-windows-x86_64
     - uses: actions/upload-artifact@v7
       with:
         name: melonDS-windows-x86_64
-        path: .\build\release-mingw-x86_64\melonDS.exe
+        path: .\build\release-windows-x86_64\melonDS.exe
     - name: Save vcpkg cache
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-x86_64-mingw-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-x86_64-windows-${{ hashFiles('vcpkg.json') }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,7 +17,17 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: x86_64
+            image: windows-2025
+          - name: arm64
+            image: windows-11-arm
+
+    name: ${{ matrix.arch.name }}
+    runs-on: ${{ matrix.arch.image }}
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
@@ -27,8 +37,8 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-x86_64-windows-${{ hashFiles('vcpkg.json') }}
-        restore-keys: vcpkg-x86_64-windows-
+        key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
+        restore-keys: vcpkg-${{ matrix.arch.name }}-windows-
     - name: Set up vcpkg
       uses: lukka/run-vcpkg@v11
       with:
@@ -36,15 +46,15 @@ jobs:
     - name: Build
       uses: lukka/run-cmake@v10
       with:
-        configurePreset: release-windows-x86_64
+        configurePreset: release-windows-${{ matrix.arch.name }}
         configurePresetAdditionalArgs: "['-DENABLE_DEBUG_DEPS=OFF', '-DMELONDS_EMBED_BUILD_INFO=ON']"
-        buildPreset: release-windows-x86_64
+        buildPreset: release-windows-${{ matrix.arch.name }}
     - uses: actions/upload-artifact@v7
       with:
-        name: melonDS-windows-x86_64
-        path: .\build\release-windows-x86_64\melonDS.exe
+        name: melonDS-windows-${{ matrix.arch.name }}
+        path: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe
     - name: Save vcpkg cache
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-x86_64-windows-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,8 +54,9 @@
       "hidden": true,
       "displayName": "Windows base",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-cl.exe",
-        "CMAKE_CXX_COMPILER": "clang-cl.exe"
+        "CMAKE_C_COMPILER": "clang.exe",
+        "CMAKE_CXX_COMPILER": "clang++.exe",
+        "CMAKE_RC_COMPILER": "llvm-rc.exe"
       },
       "condition": {
         "type": "equals",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,8 +3,8 @@
 		"default-registry": {
 			"kind": "git",
 			"repository": "https://github.com/Microsoft/vcpkg",
-			"baseline": "55fab67aea1027f7179ae6b5c54a5ba9091c16aa",
-			"reference": "55fab67aea1027f7179ae6b5c54a5ba9091c16aa"
+			"baseline": "c3867e714dd3a51c272826eea77267876517ed99",
+			"reference": "c3867e714dd3a51c272826eea77267876517ed99"
 		},
 		"overlay-ports": [ "./cmake/overlay-ports" ],
 		"overlay-triplets": [ "./cmake/overlay-triplets" ]


### PR DESCRIPTION
Seems like another package update broke the CI builds again, and I've been wanting to do this anyway so here we are.

melonDS can be built using the standard Windows SDK and the Clang compiler that ships with it instead of relying on MSYS2, this should lead to a more stable build environment and also cut out some dependencies of the CI build.

Additionally, at least one person on the Discord has had problems with the MSYS2-based builds not running properly on their system, while the Windows SDK ones have no such issue, so this may also increase compatibility?

This also adds Windows on ARM builds.