### PR TITLE
Added virtual cursor with stylus mapping

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES_QT_SDL
     EmuInstanceAudio.cpp
     EmuInstanceInput.cpp
     EmuThread.cpp
+    Cursor.cpp
     CheatImportDialog.cpp
     CheatsDialog.cpp
     Config.cpp

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -96,6 +96,7 @@ RangeList IntRanges =
 DefaultList<bool> DefaultBools =
 {
     {"Screen.Filter", true},
+    {"Mouse.Hide", true},
     {"3D.Soft.Threaded", true},
     {"3D.GL.HiresCoordinates", true},
     {"LimitFPS", true},

--- a/src/frontend/qt_sdl/Cursor.cpp
+++ b/src/frontend/qt_sdl/Cursor.cpp
@@ -265,13 +265,6 @@ void Cursor::runMacro(){
 
 void Cursor::setRotation(int rot){
   rotation = rot;
-  if (layout == 2){
-    rotation = 0;
-  } else if (layout == 5){
-    rotation = 3;
-  } else if (layout == 6){
-    rotation = 1;
-  }
 }
 void Cursor::setLayout(int lay){
   layout = lay;

--- a/src/frontend/qt_sdl/Cursor.cpp
+++ b/src/frontend/qt_sdl/Cursor.cpp
@@ -1,0 +1,303 @@
+#include "Cursor.h"
+#include <cmath>
+#include <algorithm>
+#include "EmuInstance.h"
+#include "Platform.h"
+
+
+
+void Cursor::update(){
+  if (emuInstance != nullptr){
+    for (int i = 0; i < 6; i++){
+      stylusInput[i] = std::max(emuInstance->stylusJInput[i], emuInstance->stylusKInput[i]);
+    } 
+    if (deviceInUse == 0){
+      if (inMacro){
+        runMacro();
+      } else {
+        // Reset the cursor position if macro was just played
+        if (justFinishedMacro > 0){
+          justFinishedMacro = 0;
+          rawCursorPos[0] = macroInitPos[0];
+          rawCursorPos[1] = macroInitPos[1];
+        }
+
+        // Macros
+        if (emuInstance->modButtons[0]){
+          circle(0);
+          return;
+        } else if (emuInstance->modButtons[1]){
+          rub();
+          return;
+        } else if (emuInstance->modButtons[10]){
+          if (!macroBtnPressed){
+            // Add macro
+            return;
+          }
+        } else if (emuInstance->modButtons[11]){
+          circle(1);
+          return;
+        } else {
+          if (macroBtnPressed){
+            macroBtnPressed = false;
+          }
+        }
+
+        // Compare Left vs Right Values
+        if (stylusInput[2] > stylusInput[3]){
+          normStylusDirection[0] = -(stylusInput[2]/32767.0f);
+        } else if (stylusInput[3] > stylusInput[2]) {
+          normStylusDirection[0] = (stylusInput[3]/32767.0f);
+        } else {
+          normStylusDirection[0] = 0;
+        }
+
+        // Compare Up vs Down Values
+        if (stylusInput[0] > stylusInput[1]){
+          normStylusDirection[1] = -(stylusInput[0]/32767.0f);
+        } else if (stylusInput[1] > stylusInput[0]){
+          normStylusDirection[1] = (stylusInput[1]/32767.0f);
+        } else {
+          normStylusDirection[1] = 0;
+        }
+
+        normStylusDirection[0] = std::min(normStylusDirection[0], 1.0f);
+        normStylusDirection[1] = std::min(normStylusDirection[1], 1.0f);
+
+        int maxSpeed = 50;
+        float multiplier = 0.5f * pow(4.0f, maxSpeed / 100.0f); // 0 is 0.5x speed, 100 is 2.0x speed.
+        float heightSpeed = (192.0f / 33.0f) * multiplier;
+
+        float deadzone = 10.0f / 100.0f;
+        bool stylusModPressed = stylusInput[4]; 
+        float responsecurve = 175.0f / 100.0f;
+        float speedupratio = 400.0f / 100.0f;
+        float joystickScaled[2] = {0.0f};
+        float radialLength = std::sqrt((normStylusDirection[0] * normStylusDirection[0]) + (normStylusDirection[1] * normStylusDirection[1]));
+        float finalLength;
+        float curvedLength;
+        if (radialLength > deadzone) {
+            // Get X and Y as a relation to the radial length
+            float rComponents[2];
+            rComponents[0] = normStylusDirection[0]/radialLength;
+            rComponents[1] = normStylusDirection[1]/radialLength;
+            // Apply deadzone and response curve
+            float scaledLength = (radialLength - deadzone) / (1.0f - deadzone);
+            curvedLength = std::pow(std::min<float>(1.0f, scaledLength), responsecurve);
+            // Final output
+            finalLength = stylusModPressed ? curvedLength * speedupratio : curvedLength;
+            joystickScaled[0] = rComponents[0] * finalLength;
+            joystickScaled[1] = rComponents[1] * finalLength;
+        } else {
+            joystickScaled[2] = {0.0f};
+        }
+        // The code below sets the cursor position to the position of the joystick (absolute). Needs to be readjusted for standalone melonDS
+        // _joystickCursorPosition = vec2((NDS_SCREEN_WIDTH/2.0f)+(std::min<float>(1.0,(normStylusDirection[0]/0.7071))*(NDS_SCREEN_WIDTH/2.0f)), (NDS_SCREEN_HEIGHT/2.0f)+(std::min<float>(1.0,(normStylusDirection[1]/0.7071))*(NDS_SCREEN_HEIGHT/2.0f)));
+
+        float tempX = joystickScaled[0];
+        float tempY = joystickScaled[1];
+
+        switch (rotation)
+        {
+            case 1: // 90°
+                joystickScaled[0] =  tempY;
+                joystickScaled[1] = -tempX;
+                break;
+            case 2: // 180°
+                joystickScaled[0] = -tempX;
+                joystickScaled[1] = -tempY;
+                break;
+            case 3: // 270°
+                joystickScaled[0] = -tempY;
+                joystickScaled[1] =  tempX;
+                break;
+            default:
+                break;
+        }
+
+        rawCursorPos[0] += joystickScaled[0]*heightSpeed;
+        rawCursorPos[1] += joystickScaled[1]*heightSpeed;
+
+        // Clamp to region and ready position information for touchscreen
+        clamp();
+        updateCursorPos();
+
+        // Handle stylus touch button presses
+        if (stylusInput[5]){
+          touchScreen();
+          wasTouching = true;
+        } else if (wasTouching && !stylusInput[5]){
+          release();
+          wasTouching = false;
+        }
+      }
+    } else {
+      //Update cursor based on mouse position
+      clamp();
+      updateCursorPos();
+
+      // Handle stylus touch button presses
+      if (stylusInput[5]){
+        touchScreen();
+        wasTouching = true;
+      } else if (wasTouching && !stylusInput[5]){
+        release();
+        wasTouching = false;
+      }
+
+      setDeviceInUse(0);
+    }
+  }
+}
+
+void Cursor::setDeviceInUse(int device){
+  deviceInUse = device;
+}
+
+void Cursor::setRawCursorPos(float x, float y){
+  rawCursorPos[0] = x;
+  rawCursorPos[1] = y;
+}
+
+void Cursor::clamp(){
+  rawCursorPos[0] = std::clamp(rawCursorPos[0], 0.0f, 255.0f);
+  rawCursorPos[1] = std::clamp(rawCursorPos[1], 0.0f, 191.0f);
+}
+
+void Cursor::touchScreen(){
+  emuInstance->touchScreen(cursorPos[0], cursorPos[1]);
+}
+
+void Cursor::release(){
+  emuInstance->releaseScreen();
+}
+void Cursor::setEmuInstance(EmuInstance* emuInstance){
+  this->emuInstance = emuInstance;
+}
+
+void Cursor::updateCursorPos(){
+  cursorPos[0] = std::floor(rawCursorPos[0]);
+  cursorPos[1] = std::floor(rawCursorPos[1]);
+}
+
+void Cursor::circle(int direction){
+  macroBtnPressed = true;
+  inMacro = true;
+  wasTouching = true;
+  macroType = 1;
+  float radius = 192.0f/4.0f;
+  if (justFinishedMacro != 1){ // Set the original position if just starting
+    macroInitPos = {rawCursorPos[0],  rawCursorPos[1]};
+  }
+
+
+  std::vector<std::array<float, 2>> offsetArray;
+  if (direction == 0){
+    offsetArray.push_back({(0.0f*radius),      (-1.0f*radius)});
+    offsetArray.push_back({(0.7071f*radius),   (-0.7071f*radius)});
+    offsetArray.push_back({(1.0f*radius),      (0.0f*radius)});
+    offsetArray.push_back({(0.7071f*radius),   (0.7071f*radius)});
+    offsetArray.push_back({(0.0f*radius),      (1.0f*radius)});
+    offsetArray.push_back({(-0.7071f*radius),  (0.7071f*radius)});
+    offsetArray.push_back({(-1.0f*radius),     (0.0f*radius)});
+    offsetArray.push_back({(-0.7071f*radius),  (-0.7071f*radius)});
+  } else {
+    offsetArray.push_back({(0.0f*radius),      (-1.0f*radius)});
+    offsetArray.push_back({(-0.7071f*radius),  (-0.7071f*radius)});
+    offsetArray.push_back({(-1.0f*radius),     (0.0f*radius)});
+    offsetArray.push_back({(-0.7071f*radius),  (0.7071f*radius)});
+    offsetArray.push_back({(0.0f*radius),      (1.0f*radius)});
+    offsetArray.push_back({(0.7071f*radius),   (0.7071f*radius)});
+    offsetArray.push_back({(1.0f*radius),      (0.0f*radius)});
+    offsetArray.push_back({(0.7071f*radius),   (-0.7071f*radius)});
+  }
+  offsetArray = rotateVector(offsetArray);
+
+  for (int i = 0; i < offsetArray.size(); i++){
+      macroPositions.push_back({rawCursorPos[0]+offsetArray[i][0], rawCursorPos[1]+offsetArray[i][1]});
+  }
+  macroFrames = macroPositions.size();
+  runMacro();
+}
+
+void Cursor::rub(){
+  macroBtnPressed = true;
+  inMacro = true;
+  wasTouching = true;
+  macroType = 2;
+  float radius = 192.0f/6.0f;
+  if (justFinishedMacro != 2){ // Set the original position if just starting
+    macroInitPos = {rawCursorPos[0],  rawCursorPos[1]};
+  }
+  std::vector<std::array<float, 2>> offsetArray;
+  offsetArray.push_back({(0.0f*radius),   0});
+  offsetArray.push_back({(0.5f*radius),   0});
+  offsetArray.push_back({(1.0f*radius),   0});
+  offsetArray.push_back({(0.5f*radius),   0});
+  offsetArray.push_back({(0.0f*radius),   0});
+  offsetArray.push_back({(-0.5f*radius),  0});
+  offsetArray.push_back({(-1.0f*radius),  0});
+  offsetArray.push_back({(-0.5f*radius),  0});
+  offsetArray = rotateVector(offsetArray);
+  
+  for (int i = 0; i < offsetArray.size(); i++){
+      macroPositions.push_back({rawCursorPos[0]+offsetArray[i][0], rawCursorPos[1]+offsetArray[i][1]});
+  }
+  macroFrames = macroPositions.size();
+  runMacro();
+}
+
+
+void Cursor::runMacro(){
+    rawCursorPos[0] = macroPositions.front()[0];
+    rawCursorPos[1] = macroPositions.front()[1];
+    macroPositions.pop_front();
+    clamp();
+    updateCursorPos();
+    touchScreen();
+    macroFrames--;
+    if (macroFrames == 0){
+      macroPositions.clear();
+      inMacro = false;
+      justFinishedMacro = macroType;
+    }
+}
+
+void Cursor::setRotation(int rot){
+  rotation = rot;
+  if (layout == 2){
+    rotation = 0;
+  } else if (layout == 5){
+    rotation = 3;
+  } else if (layout == 6){
+    rotation = 1;
+  }
+}
+void Cursor::setLayout(int lay){
+  layout = lay;
+}
+
+std::vector<std::array<float, 2>> Cursor::rotateVector(std::vector<std::array<float, 2>> input){
+  for (auto& currArray : input){
+      float tempX = currArray[0];
+      float tempY = currArray[1];
+      switch (rotation)
+      {
+          case 1: // 90°
+              currArray[0] =  tempY;
+              currArray[1] = -tempX;
+              break;
+          case 2: // 180°
+              currArray[0] = -tempX;
+              currArray[1] = -tempY;
+              break;
+          case 3: // 270°
+              currArray[0] = -tempY;
+              currArray[1] =  tempX;
+              break;
+          default:
+              break;
+    }
+  }
+  return input;
+}

--- a/src/frontend/qt_sdl/Cursor.h
+++ b/src/frontend/qt_sdl/Cursor.h
@@ -1,0 +1,48 @@
+#ifndef CURSOR_H
+#define CURSOR_H
+#include <queue>
+#include <array>
+#include <vector>
+class EmuInstance;
+
+class Cursor
+{
+public:
+  void update();
+  void setRawCursorPos(float x, float y);
+  void setDeviceInUse(int device);
+  void setEmuInstance(EmuInstance* emuInstance);
+  void setRotation(int rot);
+  void setLayout(int layout);
+  int cursorPos[2];
+  float normStylusDirection[2];
+  bool cursorEnabled = true;
+private:
+  EmuInstance* emuInstance = nullptr;
+  float rawCursorPos[2] = {127, 95};
+  void touchScreen();
+  void release();
+  void clamp();
+  void updateCursorPos();
+  bool wasTouching;
+  int stylusInput[6] = {0};
+  //Swipe in direction of x and y over the course of specified frames. Expects integer values between -1 and 1
+  // void swipe(float x, float y, int frames);
+  void circle(int direction); //0 is clockwise, 1 is counter clockwise
+  void rub();
+  void runMacro();
+
+  std::vector<std::array<float, 2>> rotateVector(std::vector<std::array<float, 2>> input);
+  bool inMacro;
+  std::deque<std::array<float, 2>> macroPositions;
+  int macroFrames;
+  bool macroBtnPressed;
+  int macroType;
+  int justFinishedMacro;
+  std::array<float, 2> macroInitPos;
+  int rotation;
+  int layout;
+  int deviceInUse; //0 is Gamepad, 1 is Mouse/Tablet
+};
+
+#endif // CURSOR_H

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -142,7 +142,7 @@ public:
                          melonDS::u32 (&animatedIconRef)[64][32*32],
                          std::vector<int> &animatedSequenceRef);
 
-    static const char* buttonNames[12];
+    static const char* buttonNames[18];
     static const char* hotkeyNames[HK_MAX];
 
     void inputInit();
@@ -168,6 +168,10 @@ public:
     int micReadInput(melonDS::s16* data, int maxlength);
 
     QMutex renderLock;
+
+    bool hotkeyDown(int id)     { return hotkeyMask    & (1<<id); }
+    bool hotkeyPressed(int id)  { return hotkeyPress   & (1<<id); }
+    bool hotkeyReleased(int id) { return hotkeyRelease & (1<<id); }
 
 private:
     static int lastSep(const std::string& path);
@@ -248,13 +252,9 @@ private:
 
     void openJoystick();
     void closeJoystick();
-    bool joystickButtonDown(int val);
+    bool joystickButtonDown(int val, int index);
 
     void inputProcess();
-
-    bool hotkeyDown(int id)     { return hotkeyMask    & (1<<id); }
-    bool hotkeyPressed(int id)  { return hotkeyPress   & (1<<id); }
-    bool hotkeyReleased(int id) { return hotkeyRelease & (1<<id); }
 
     void loadRTCData();
     void saveRTCData();
@@ -304,6 +304,13 @@ public:
     bool fastForwardToggled;
     bool slowmoToggled;
     bool doAudioSync;
+
+    //Stylus Direction: Up, Down, Left, Right, Mod, Touch
+    //First 4 indices are 0-32768, Next two are 0-1.
+    uint stylusKInput[6] = {0};
+    uint stylusJInput[6] = {0};
+    //Face Button with Stylus Mod held (Nintendo Layout). A (0), B (1), X (10), Y (11)
+    uint modButtons[12] = {0};
 private:
 
     std::unique_ptr<melonDS::Savestate> backupState;
@@ -351,8 +358,8 @@ private:
     std::string micDeviceName;
     std::string micWavPath;
 
-    int keyMapping[12];
-    int joyMapping[12];
+    int keyMapping[18];
+    int joyMapping[18];
     int hkKeyMapping[HK_MAX];
     int hkJoyMapping[HK_MAX];
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -27,7 +27,7 @@
 
 using namespace melonDS;
 
-const char* EmuInstance::buttonNames[12] =
+const char* EmuInstance::buttonNames[18] =
 {
     "A",
     "B",
@@ -40,7 +40,13 @@ const char* EmuInstance::buttonNames[12] =
     "R",
     "L",
     "X",
-    "Y"
+    "Y",
+    "StyUp",
+    "StyDown",
+    "StyLeft",
+    "StyRight",
+    "StyMod",
+    "StyTouch"
 };
 
 const char* EmuInstance::hotkeyNames[HK_MAX] =
@@ -119,7 +125,7 @@ void EmuInstance::inputLoadConfig()
     Config::Table keycfg = localCfg.GetTable("Keyboard");
     Config::Table joycfg = localCfg.GetTable("Joystick");
 
-    for (int i = 0; i < 12; i++)
+    for (int i = 0; i < 18; i++)
     {
         keyMapping[i] = keycfg.GetInt(buttonNames[i]);
         joyMapping[i] = joycfg.GetInt(buttonNames[i]);
@@ -326,9 +332,18 @@ void EmuInstance::onKeyPress(QKeyEvent* event)
     if (event->modifiers() != Qt::KeypadModifier)
         keyKP &= ~event->modifiers();
 
-    for (int i = 0; i < 12; i++)
-        if (keyKP == keyMapping[i])
-            keyInputMask &= ~(1<<i);
+    for (int i = 0; i < 18; i++){
+        if (keyKP == keyMapping[i]){
+            if (i > 11 && i < 16){
+                stylusKInput[i-12] = 32767;
+            } else if (i == 16 || i == 17){
+                stylusKInput[i-12] = 1;
+            } else {
+                keyInputMask &= ~(1<<i);
+            }
+        }
+    }
+
 
     for (int i = 0; i < HK_MAX; i++)
         if (keyHK == hkKeyMapping[i])
@@ -342,9 +357,18 @@ void EmuInstance::onKeyRelease(QKeyEvent* event)
     if (event->modifiers() != Qt::KeypadModifier)
         keyKP &= ~event->modifiers();
 
-    for (int i = 0; i < 12; i++)
-        if (keyKP == keyMapping[i])
-            keyInputMask |= (1<<i);
+    for (int i = 0; i < 18; i++){
+        if (keyKP == keyMapping[i]){
+            if (i > 11 && i < 16){
+                stylusKInput[i-12] = 0;
+            } else if (i == 16 || i == 17){
+                stylusKInput[i-12] = 0;
+            } else {
+                keyInputMask |= (1<<i);
+            }
+        }
+    }
+
 
     for (int i = 0; i < HK_MAX; i++)
         if (keyHK == hkKeyMapping[i])
@@ -357,8 +381,9 @@ void EmuInstance::keyReleaseAll()
     keyHotkeyMask = 0;
 }
 
-bool EmuInstance::joystickButtonDown(int val)
+bool EmuInstance::joystickButtonDown(int val, int index)
 {
+    //Stylus Values are stored in a separate variable
     if (val == -1) return false;
 
     bool hasbtn = ((val & 0xFFFF) != 0xFFFF);
@@ -377,14 +402,46 @@ bool EmuInstance::joystickButtonDown(int val)
             else if (hatdir == 0x2) pressed = (hatval & SDL_HAT_RIGHT);
             else if (hatdir == 0x8) pressed = (hatval & SDL_HAT_LEFT);
 
-            if (pressed) return true;
+            if (index > 11 && index < 16){ //Stylus Direction
+                if (pressed){
+                    stylusJInput[index-12] = 32767;
+                } else {
+                    stylusJInput[index-12] = 0;
+                }
+            } else if (index == 16 || index == 17) { //Stylus Mod or Touch
+                if (pressed){
+                    stylusJInput[index-12] = 1;
+                } else {
+                    stylusJInput[index-12] = 0;
+                }
+            } else {
+                if (pressed){
+                    return true;
+                }
+            } 
         }
         else
         {
             int btnnum = val & 0xFFFF;
             Uint8 btnval = SDL_JoystickGetButton(joystick, btnnum);
 
-            if (btnval) return true;
+            if (index > 11 && index < 16){ //Stylus Direction
+                if (btnval){
+                    stylusJInput[index-12] = 32767;
+                } else {
+                    stylusJInput[index-12] = 0;
+                }
+            } else if (index == 16 || index == 17) { //Stylus Mod or Touch
+                if (btnval){
+                    stylusJInput[index-12] = 1;
+                } else {
+                    stylusJInput[index-12] = 0;
+                }
+            } else {
+                if (btnval){
+                    return true;
+                }
+            } 
         }
     }
 
@@ -393,20 +450,67 @@ bool EmuInstance::joystickButtonDown(int val)
         int axisnum = (val >> 24) & 0xF;
         int axisdir = (val >> 20) & 0xF;
         Sint16 axisval = SDL_JoystickGetAxis(joystick, axisnum);
-
-        switch (axisdir)
-        {
-            case 0: // positive
-                if (axisval > 16384) return true;
-                break;
-
-            case 1: // negative
-                if (axisval < -16384) return true;
-                break;
-
-            case 2: // trigger
-                if (axisval > 0) return true;
-                break;
+        if (axisdir == 2){ // trigger
+                // Uses 50% deadzone
+                if (index > 11 && index < 16){ //Stylus Direction
+                    if (axisval > 0){
+                        stylusJInput[index-12] = 32767;
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                } else if (index == 16 || index == 17) { //Stylus Mod or Touch
+                    if (axisval > 0){
+                        stylusJInput[index-12] = 1;
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                } else {
+                    if (axisval > 0){
+                        return true;
+                    }
+                }
+        } else {
+            //Note: Both the negative and positive axis return the same value (signed integer representing x/y coordinate)
+            //      Use axisdir to see if the value matches the sign attached to the current input
+            if (index > 11 && index < 16){ //Stylus Up, Down, Left or Right
+                if (axisdir == 0){ //Positive Axis Direction
+                    if (axisval > 0){ //Value is in same direction
+                        stylusJInput[index-12] = std::abs(axisval);
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                } else { //Negative Axis Direction
+                    if (axisval < 0){ //Value is in same direction
+                        stylusJInput[index-12] = std::abs(axisval);
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                }
+            } else if (index == 16 || index == 17) { //Stylus Mod or Touch
+                if (axisdir == 0){ //Positive Axis Direction
+                    if (axisval > 16384){ //Matching Value
+                        stylusJInput[index-12] = 1;
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                } else { //Negative Axis Direction
+                    if (axisval < -16384){ //Matching Value
+                        stylusJInput[index-12] = 1;
+                    } else {
+                        stylusJInput[index-12] = 0;
+                    }
+                }
+            } else {
+                if (axisdir == 0){ //Positive Axis Direction
+                    if (axisval > 16384){ //Matching Value
+                        return true;
+                    } 
+                } else { //Negative Axis Direction
+                    if (axisval < -16384){ //Matching Value
+                        return true;
+                    }
+                }
+            }
         }
     }
 
@@ -434,9 +538,25 @@ void EmuInstance::inputProcess()
     joyInputMask = 0xFFF;
     if (joystick)
     {
-        for (int i = 0; i < 12; i++)
-            if (joystickButtonDown(joyMapping[i]))
-                joyInputMask &= ~(1 << i);
+        //Scan Stylus inputs first
+        for (int i = 12; i < 18; i++){
+            joystickButtonDown(joyMapping[i], i);
+        }
+        for (int i = 0; i < 12; i++){
+            if (joystickButtonDown(joyMapping[i], i)){
+                if (stylusJInput[4] == 1 && (i == 0 || i == 1 || i == 10 || i == 11)){
+                        modButtons[i] = 1;
+                } else {
+                    joyInputMask &= ~(1 << i);
+                }
+            } else {
+                if (i == 0 || i == 1 || i == 10 || i == 11){
+                    modButtons[i] = 0;
+                }
+            } 
+                    
+        }
+                
     }
 
     inputMask = keyInputMask & joyInputMask;
@@ -445,7 +565,7 @@ void EmuInstance::inputProcess()
     if (joystick)
     {
         for (int i = 0; i < HK_MAX; i++)
-            if (joystickButtonDown(hkJoyMapping[i]))
+            if (joystickButtonDown(hkJoyMapping[i], i))
                 joyHotkeyMask |= (1 << i);
     }
 

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
@@ -34,8 +34,8 @@
 using namespace melonDS;
 InputConfigDialog* InputConfigDialog::currentDlg = nullptr;
 
-const int dskeyorder[12] = {0, 1, 10, 11, 5, 4, 6, 7, 9, 8, 2, 3};
-const char* dskeylabels[12] = {"A", "B", "X", "Y", "Left", "Right", "Up", "Down", "L", "R", "Select", "Start"};
+const int dskeyorder[18] = {0, 1, 10, 11, 5, 4, 6, 7, 9, 8, 2, 3, 12, 13, 14, 15, 16, 17};
+const char* dskeylabels[18] = {"A", "B", "X", "Y", "Left", "Right", "Up", "Down", "L", "R", "Select", "Start","StyUp", "StyDown", "StyLeft", "StyRight", "StyMod", "StyTouch"};
 
 InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new Ui::InputConfigDialog)
 {

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -26,7 +26,7 @@
 #include "Config.h"
 #include "EmuInstance.h"
 
-static constexpr int keypad_num = 12;
+static constexpr int keypad_num = 18;
 
 static constexpr std::initializer_list<int> hk_addons =
 {
@@ -145,7 +145,7 @@ private:
 
     EmuInstance* emuInstance;
 
-    int keypadKeyMap[12], keypadJoyMap[12];
+    int keypadKeyMap[18], keypadJoyMap[18];
     int addonsKeyMap[hk_addons.size()], addonsJoyMap[hk_addons.size()];
     int hkGeneralKeyMap[hk_general.size()], hkGeneralJoyMap[hk_general.size()];
     int joystickID;

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>770</width>
-    <height>678</height>
+    <width>807</width>
+    <height>757</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,15 +18,64 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
+    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
    </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblInstanceNum">
+     <property name="text">
+      <string>Configuring mappings for instance X</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Joystick:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cbxJoystick">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects which joystick will be used for joystick input, if any is present.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="8" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -43,16 +92,16 @@
        <item row="0" column="0">
         <widget class="QStackedWidget" name="stackMapping">
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="keyPage">
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="4" column="1" colspan="3">
+           <item row="6" column="1" colspan="3">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <spacer name="horizontalSpacer">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -72,7 +121,7 @@
              <item>
               <spacer name="horizontalSpacer_2">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -84,6 +133,22 @@
              </item>
             </layout>
            </item>
+           <item row="1" column="2">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="pixmap">
+              <pixmap resource="resources/ds.qrc">:/ds/ds_back.svg</pixmap>
+             </property>
+             <property name="scaledContents">
+              <bool>false</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
            <item row="1" column="3">
             <widget class="QWidget" name="widget_4" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_15">
@@ -93,7 +158,7 @@
                  <string/>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignCenter</set>
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout">
                  <property name="spacing">
@@ -114,10 +179,10 @@
                  <item>
                   <widget class="QLabel" name="label_8">
                    <property name="text">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -149,7 +214,7 @@
               <item>
                <spacer name="horizontalSpacer_8">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -158,84 +223,6 @@
                  </size>
                 </property>
                </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QWidget" name="widget_3" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_14">
-              <item>
-               <spacer name="horizontalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="grp_L">
-                <property name="title">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_4">
-                 <property name="spacing">
-                  <number>3</number>
-                 </property>
-                 <property name="leftMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>3</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="label_9">
-                   <property name="text">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;L&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="btnKeyL">
-                   <property name="minimumSize">
-                    <size>
-                     <width>70</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>68</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true">min-width: 68px;</string>
-                   </property>
-                   <property name="text">
-                    <string>L</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
               </item>
              </layout>
             </widget>
@@ -294,7 +281,7 @@
                  <item>
                   <spacer name="spacer_3">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -304,13 +291,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_X">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonFaceButtonsXVerticalLayout">
                     <property name="spacing">
@@ -331,10 +318,10 @@
                     <item>
                      <widget class="QLabel" name="label_13">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
@@ -366,7 +353,7 @@
                  <item>
                   <spacer name="spacer_4">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -384,13 +371,13 @@
                 <property name="spacing">
                  <number>3</number>
                 </property>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Y">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonFaceButtonsYVerticalLayout">
                    <property name="spacing">
@@ -411,10 +398,10 @@
                    <item>
                     <widget class="QLabel" name="label_15">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -443,13 +430,13 @@
                   </layout>
                  </widget>
                 </item>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_A">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonFaceButtonsAVerticalLayout">
                    <property name="spacing">
@@ -470,10 +457,10 @@
                    <item>
                     <widget class="QLabel" name="label_16">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;A&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -525,7 +512,7 @@
                  <item>
                   <spacer name="spacer_5">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -535,13 +522,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_B">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonFaceButtonsBVerticalLayout">
                     <property name="spacing">
@@ -562,10 +549,10 @@
                     <item>
                      <widget class="QLabel" name="label_17">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;B&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;B&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
@@ -597,7 +584,7 @@
                  <item>
                   <spacer name="spacer_6">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -612,131 +599,6 @@
               </item>
              </layout>
             </widget>
-           </item>
-           <item row="3" column="2">
-            <layout class="QHBoxLayout" name="layout_SelectStart">
-             <property name="spacing">
-              <number>3</number>
-             </property>
-             <item alignment="Qt::AlignHCenter">
-              <widget class="QGroupBox" name="grp_Select">
-               <property name="title">
-                <string/>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout_2">
-                <property name="spacing">
-                 <number>3</number>
-                </property>
-                <property name="leftMargin">
-                 <number>3</number>
-                </property>
-                <property name="topMargin">
-                 <number>3</number>
-                </property>
-                <property name="rightMargin">
-                 <number>3</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>3</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_18">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Select&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnKeySelect">
-                  <property name="minimumSize">
-                   <size>
-                    <width>70</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>68</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">min-width: 68px;</string>
-                  </property>
-                  <property name="text">
-                   <string>Select</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignHCenter">
-              <widget class="QGroupBox" name="grp_Start">
-               <property name="title">
-                <string/>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout_2">
-                <property name="spacing">
-                 <number>3</number>
-                </property>
-                <property name="leftMargin">
-                 <number>3</number>
-                </property>
-                <property name="topMargin">
-                 <number>3</number>
-                </property>
-                <property name="rightMargin">
-                 <number>3</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>3</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_19">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Start&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnKeyStart">
-                  <property name="minimumSize">
-                   <size>
-                    <width>70</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>68</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">min-width: 68px;</string>
-                  </property>
-                  <property name="text">
-                   <string>Start</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
            </item>
            <item row="2" column="1">
             <widget class="QGroupBox" name="grp_ControlPad">
@@ -792,7 +654,7 @@
                  <item>
                   <spacer name="spacer">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -802,13 +664,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_Up">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonDpadUpVerticalLayout">
                     <property name="spacing">
@@ -829,10 +691,10 @@
                     <item>
                      <widget class="QLabel" name="label_10">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Up&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
@@ -864,7 +726,7 @@
                  <item>
                   <spacer name="spacer_2">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -882,13 +744,13 @@
                 <property name="spacing">
                  <number>3</number>
                 </property>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Left">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout">
                    <property name="spacing">
@@ -909,10 +771,10 @@
                    <item>
                     <widget class="QLabel" name="label_11">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Left&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Left&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -941,13 +803,13 @@
                   </layout>
                  </widget>
                 </item>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Right">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout">
                    <property name="spacing">
@@ -968,10 +830,10 @@
                    <item>
                     <widget class="QLabel" name="label_12">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Right&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -1023,7 +885,7 @@
                  <item>
                   <spacer name="spacer_7">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1033,13 +895,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item>
                   <widget class="QGroupBox" name="grp_Down">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout">
                     <property name="spacing">
@@ -1060,14 +922,14 @@
                     <item>
                      <widget class="QLabel" name="label_14">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Down&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QPushButton" name="btnKeyDown">
                       <property name="minimumSize">
                        <size>
@@ -1095,7 +957,7 @@
                  <item>
                   <spacer name="spacer_8">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1122,18 +984,8 @@
              <property name="scaledContents">
               <bool>false</bool>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="pixmap">
-              <pixmap resource="resources/ds.qrc">:/ds/ds_back.svg</pixmap>
-             </property>
-             <property name="scaledContents">
-              <bool>false</bool>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -1148,58 +1000,17 @@
               <string>Keyboard mappings</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="joyPage">
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="4" column="1" colspan="3">
-            <layout class="QHBoxLayout" name="horizontalLayout_12">
-             <item>
-              <spacer name="horizontalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnKeyMapSwitch">
-               <property name="text">
-                <string>Switch to Keyboard mappings</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
            <item row="1" column="1">
-            <widget class="QWidget" name="widget" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <widget class="QWidget" name="widget_3" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
               <item>
-               <spacer name="horizontalSpacer_6">
+               <spacer name="horizontalSpacer_7">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -1210,14 +1021,14 @@
                </spacer>
               </item>
               <item>
-               <widget class="QGroupBox" name="grp_L_2">
+               <widget class="QGroupBox" name="grp_L">
                 <property name="title">
                  <string/>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignCenter</set>
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_7">
+                <layout class="QVBoxLayout" name="verticalLayout_4">
                  <property name="spacing">
                   <number>3</number>
                  </property>
@@ -1234,17 +1045,17 @@
                   <number>3</number>
                  </property>
                  <item>
-                  <widget class="QLabel" name="label_20">
+                  <widget class="QLabel" name="label_9">
                    <property name="text">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;L&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;L&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="btnJoyL">
+                  <widget class="QPushButton" name="btnKeyL">
                    <property name="minimumSize">
                     <size>
                      <width>70</width>
@@ -1271,20 +1082,506 @@
              </layout>
             </widget>
            </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string/>
+           <item row="4" column="2">
+            <layout class="QHBoxLayout" name="layout_SelectStart">
+             <property name="spacing">
+              <number>6</number>
              </property>
-             <property name="pixmap">
-              <pixmap resource="resources/ds.qrc">:/ds/ds_back.svg</pixmap>
-             </property>
-             <property name="scaledContents">
-              <bool>false</bool>
-             </property>
-            </widget>
+             <item>
+              <widget class="QGroupBox" name="grp_Select">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout_2">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_18">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeySelect">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Select</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_Start">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout_2">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_19">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeyStart">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Start</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyMod">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <property name="checkable">
+                <bool>false</bool>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_6">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_35">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Mod&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                 <widget class="QPushButton" name="btnKeyStyMod">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Mod</string>
+                  </property>
+                  <property name="flat">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyTouch">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_7">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_36">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Touch&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeyStyTouch">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Touch</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
            </item>
-           <item row="2" column="2">
+           <item row="3" column="2">
+            <layout class="QHBoxLayout" name="layout_StylusDirections">
+             <item>
+              <widget class="QGroupBox" name="grp_StyUp">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_16">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_45">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                 <widget class="QPushButton" name="btnKeyStyUp">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Up</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyDown">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_15">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_44">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeyStyDown">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Down</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyLeft">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_14">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_43">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Left&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeyStyLeft">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Left</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyRight">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_13">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_42">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Right&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnKeyStyRight">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Right</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="joyPage">
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
             <widget class="QLabel" name="label_5">
              <property name="text">
               <string/>
@@ -1351,7 +1648,7 @@
                  <item>
                   <spacer name="spacer_13">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1361,13 +1658,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_Up_2">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonDpadUpVerticalLayout_2">
                     <property name="spacing">
@@ -1388,14 +1685,14 @@
                     <item>
                      <widget class="QLabel" name="label_23">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Up&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QPushButton" name="btnJoyUp">
                       <property name="minimumSize">
                        <size>
@@ -1423,7 +1720,7 @@
                  <item>
                   <spacer name="spacer_14">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1441,13 +1738,13 @@
                 <property name="spacing">
                  <number>3</number>
                 </property>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Left_2">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout_4">
                    <property name="spacing">
@@ -1468,10 +1765,10 @@
                    <item>
                     <widget class="QLabel" name="label_22">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Left&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Left&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -1500,13 +1797,13 @@
                   </layout>
                  </widget>
                 </item>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Right_2">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout_4">
                    <property name="spacing">
@@ -1527,10 +1824,10 @@
                    <item>
                     <widget class="QLabel" name="label_30">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Right&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -1582,7 +1879,7 @@
                  <item>
                   <spacer name="spacer_15">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1592,13 +1889,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item>
                   <widget class="QGroupBox" name="grp_Down_2">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_2">
                     <property name="spacing">
@@ -1619,10 +1916,10 @@
                     <item>
                      <widget class="QLabel" name="label_31">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Down&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
@@ -1654,7 +1951,7 @@
                  <item>
                   <spacer name="spacer_16">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1668,6 +1965,19 @@
                </widget>
               </item>
              </layout>
+            </widget>
+           </item>
+           <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="pixmap">
+              <pixmap resource="resources/ds.qrc">:/ds/ds_back.svg</pixmap>
+             </property>
+             <property name="scaledContents">
+              <bool>false</bool>
+             </property>
             </widget>
            </item>
            <item row="2" column="3">
@@ -1724,7 +2034,7 @@
                  <item>
                   <spacer name="spacer_9">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1734,13 +2044,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_X_2">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonFaceButtonsXVerticalLayout_2">
                     <property name="spacing">
@@ -1761,10 +2071,10 @@
                     <item>
                      <widget class="QLabel" name="label_24">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
@@ -1796,7 +2106,7 @@
                  <item>
                   <spacer name="spacer_10">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1814,13 +2124,13 @@
                 <property name="spacing">
                  <number>3</number>
                 </property>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_Y_2">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonFaceButtonsYVerticalLayout_2">
                    <property name="spacing">
@@ -1841,10 +2151,10 @@
                    <item>
                     <widget class="QLabel" name="label_25">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -1873,13 +2183,13 @@
                   </layout>
                  </widget>
                 </item>
-                <item alignment="Qt::AlignHCenter">
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QGroupBox" name="grp_A_2">
                   <property name="title">
                    <string/>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="buttonFaceButtonsAVerticalLayout_2">
                    <property name="spacing">
@@ -1900,10 +2210,10 @@
                    <item>
                     <widget class="QLabel" name="label_26">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;A&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignCenter</set>
+                      <set>Qt::AlignmentFlag::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
@@ -1955,7 +2265,7 @@
                  <item>
                   <spacer name="spacer_11">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1965,13 +2275,13 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignHCenter">
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QGroupBox" name="grp_B_2">
                    <property name="title">
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                    <layout class="QVBoxLayout" name="buttonFaceButtonsBVerticalLayout_2">
                     <property name="spacing">
@@ -1992,14 +2302,14 @@
                     <item>
                      <widget class="QLabel" name="label_27">
                       <property name="text">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;B&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;B&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item alignment="Qt::AlignmentFlag::AlignLeft">
                      <widget class="QPushButton" name="btnJoyB">
                       <property name="minimumSize">
                        <size>
@@ -2027,7 +2337,7 @@
                  <item>
                   <spacer name="spacer_12">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2043,18 +2353,18 @@
              </layout>
             </widget>
            </item>
-           <item row="3" column="2">
+           <item row="4" column="2">
             <layout class="QHBoxLayout" name="layout_SelectStart_2">
              <property name="spacing">
-              <number>3</number>
+              <number>6</number>
              </property>
-             <item alignment="Qt::AlignHCenter">
+             <item>
               <widget class="QGroupBox" name="grp_Select_2">
                <property name="title">
                 <string/>
                </property>
                <property name="alignment">
-                <set>Qt::AlignCenter</set>
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout_3">
                 <property name="spacing">
@@ -2075,14 +2385,14 @@
                 <item>
                  <widget class="QLabel" name="label_28">
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Select&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                  </widget>
                 </item>
-                <item>
+                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                  <widget class="QPushButton" name="btnJoySelect">
                   <property name="minimumSize">
                    <size>
@@ -2107,13 +2417,13 @@
                </layout>
               </widget>
              </item>
-             <item alignment="Qt::AlignHCenter">
+             <item>
               <widget class="QGroupBox" name="grp_Start_2">
                <property name="title">
                 <string/>
                </property>
                <property name="alignment">
-                <set>Qt::AlignCenter</set>
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout_3">
                 <property name="spacing">
@@ -2134,10 +2444,10 @@
                 <item>
                  <widget class="QLabel" name="label_29">
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Start&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignCenter</set>
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                  </widget>
                 </item>
@@ -2166,7 +2476,140 @@
                </layout>
               </widget>
              </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyMod_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_12">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_41">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Mod&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyMod">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Mod</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyTouch_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_11">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_40">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Touch&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyTouch">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Touch</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
             </layout>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_6">
+             <property name="font">
+              <font>
+               <pointsize>15</pointsize>
+              </font>
+             </property>
+             <property name="text">
+              <string>Joystick mappings</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
            </item>
            <item row="1" column="3">
             <widget class="QWidget" name="widget_2" native="true">
@@ -2177,7 +2620,7 @@
                  <string/>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignCenter</set>
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_8">
                  <property name="spacing">
@@ -2198,14 +2641,14 @@
                  <item>
                   <widget class="QLabel" name="label_21">
                    <property name="text">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
-                 <item>
+                 <item alignment="Qt::AlignmentFlag::AlignHCenter">
                   <widget class="QPushButton" name="btnJoyR">
                    <property name="minimumSize">
                     <size>
@@ -2233,7 +2676,7 @@
               <item>
                <spacer name="horizontalSpacer_5">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -2246,20 +2689,360 @@
              </layout>
             </widget>
            </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="label_6">
-             <property name="font">
-              <font>
-               <pointsize>15</pointsize>
-              </font>
-             </property>
-             <property name="text">
-              <string>Joystick mappings</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
+           <item row="1" column="1">
+            <widget class="QWidget" name="widget" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="grp_L_2">
+                <property name="title">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_7">
+                 <property name="spacing">
+                  <number>3</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>3</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>3</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>3</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>3</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="label_20">
+                   <property name="text">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;L&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnJoyL">
+                   <property name="minimumSize">
+                    <size>
+                     <width>70</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>68</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="styleSheet">
+                    <string notr="true">min-width: 68px;</string>
+                   </property>
+                   <property name="text">
+                    <string>L</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </widget>
+           </item>
+           <item row="5" column="1" colspan="3">
+            <layout class="QHBoxLayout" name="horizontalLayout_12">
+             <item>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnKeyMapSwitch">
+               <property name="text">
+                <string>Switch to Keyboard mappings</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="3" column="2">
+            <layout class="QHBoxLayout" name="layout_StylusDirections_2">
+             <item>
+              <widget class="QGroupBox" name="grp_StyUp_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_10">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_39">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Up&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyUp">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Up</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyDown_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_9">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_38">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyDown">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Down</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyLeft_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_8">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_37">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Left&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyLeft">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Left</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grp_StyRight_2">
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout_5">
+                <property name="spacing">
+                 <number>3</number>
+                </property>
+                <property name="leftMargin">
+                 <number>3</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>3</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_34">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stylus Right&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnJoyStyRight">
+                  <property name="minimumSize">
+                   <size>
+                    <width>70</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>68</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">min-width: 68px;</string>
+                  </property>
+                  <property name="text">
+                   <string>Right</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
@@ -2277,55 +3060,6 @@
        <string>General hotkeys</string>
       </attribute>
      </widget>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Joystick:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cbxJoystick">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects which joystick will be used for joystick input, if any is present.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblInstanceNum">
-     <property name="text">
-      <string>Configuring mappings for instance X</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -1198,7 +1198,7 @@ void ScreenPanelGL::drawScreen()
 
         for (int i = 0; i < numScreens; i++)
         {
-            if (i == 1 && vCursor->cursorEnabled){
+            if (screenKind[i] == 1 && vCursor->cursorEnabled){
                 glUniform1i(screenShaderCursorEnableLoc, 1);
                 glUniform2f(screenShaderCursorLoc, vCursor->cursorPos[0]/256.f, vCursor->cursorPos[1]/192.f);
             } else {

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -43,6 +43,7 @@
 #include "OSD_shaders.h"
 #include "font.h"
 #include "version.h"
+#include "Cursor.h"
 
 using namespace melonDS;
 
@@ -258,12 +259,15 @@ void ScreenPanel::mousePressEvent(QMouseEvent* event)
 
     int x = event->pos().x();
     int y = event->pos().y();
+    int xClamp = x;
+    int yClamp = y;
 
-    if (layout.GetTouchCoords(x, y, false))
-    {
-        touching = true;
-        emuInstance->touchScreen(x, y);
-    }
+    bool inTouchCoords = layout.GetTouchCoords(x, y, false);
+    bool inTouchCoordsClamp = layout.GetTouchCoords(xClamp, yClamp, true);
+
+    touching = true;
+    emuInstance->touchScreen(xClamp, yClamp);
+
 }
 
 void ScreenPanel::mouseReleaseEvent(QMouseEvent* event)
@@ -281,21 +285,31 @@ void ScreenPanel::mouseReleaseEvent(QMouseEvent* event)
 
 void ScreenPanel::mouseMoveEvent(QMouseEvent* event)
 {
-    event->accept();
-
-    showCursor();
-
-    if (!emuInstance->emuIsActive()) return;
+    event->accept();    
+    if (!emuInstance->emuIsActive()){
+        showCursor();
+        return;
+    }
     //if (!(event->buttons() & Qt::LeftButton)) return;
-    if (!touching) return;
 
     int x = event->pos().x();
     int y = event->pos().y();
+    int xClamp = x;
+    int yClamp = y;
 
-    if (layout.GetTouchCoords(x, y, true))
-    {
-        emuInstance->touchScreen(x, y);
+    bool inTouchCoords = layout.GetTouchCoords(x, y, false);
+    bool inTouchCoordsClamp = layout.GetTouchCoords(xClamp, yClamp, true);
+    
+    vCursor->setDeviceInUse(1);
+    vCursor->setRawCursorPos(xClamp, yClamp); 
+    if (vCursor->cursorEnabled && inTouchCoords){
+        setCursor(Qt::BlankCursor);
+    } else {
+        showCursor();
     }
+    if (!touching) return;
+
+    emuInstance->touchScreen(xClamp, yClamp);
 }
 
 void ScreenPanel::tabletEvent(QTabletEvent* event)
@@ -806,6 +820,9 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
     
     if (emuThread->emuIsActive())
     {
+        if (emuThread->emuIsRunning()){
+            vCursor->update();
+        }
         emuInstance->renderLock.lock();
 
         bufferLock.lock();
@@ -817,6 +834,19 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
         bufferLock.unlock();
 
         QRect screenrc(0, 0, 256, 192);
+
+        //Crosshair Painter
+        if (vCursor->cursorEnabled){
+            QPainter cPainter(&screen[1]);
+            cPainter.setPen(Qt::black);
+            cPainter.setBrush(Qt::black);
+            cPainter.drawRect(vCursor->cursorPos[0]-4, vCursor->cursorPos[1]-1, 8, 2);
+            cPainter.drawRect(vCursor->cursorPos[0]-1, vCursor->cursorPos[1]-4, 2, 8);
+            cPainter.setPen(Qt::white);
+            cPainter.drawLine(vCursor->cursorPos[0]-3, vCursor->cursorPos[1], vCursor->cursorPos[0]+3, vCursor->cursorPos[1]);
+            cPainter.drawLine(vCursor->cursorPos[0], vCursor->cursorPos[1]-3, vCursor->cursorPos[0], vCursor->cursorPos[1]+3);
+            cPainter.end();
+        }
 
         for (int i = 0; i < numScreens; i++)
         {
@@ -932,7 +962,8 @@ void ScreenPanelGL::initOpenGL()
     glUseProgram(screenShaderProgram);
     glUniform1i(glGetUniformLocation(screenShaderProgram, "TopScreenTex"), 0);
     glUniform1i(glGetUniformLocation(screenShaderProgram, "BottomScreenTex"), 1);
-
+    screenShaderCursorLoc = glGetUniformLocation(screenShaderProgram, "cursorPos");
+    screenShaderCursorEnableLoc = glGetUniformLocation(screenShaderProgram, "cursorEnable");
     screenShaderScreenSizeULoc = glGetUniformLocation(screenShaderProgram, "uScreenSize");
     screenShaderTransformULoc = glGetUniformLocation(screenShaderProgram, "uTransform");
 
@@ -1126,6 +1157,9 @@ void ScreenPanelGL::drawScreen()
 
     if (emuThread->emuIsActive())
     {
+        if (emuThread->emuIsRunning()){
+            vCursor->update();
+        }
         auto nds = emuInstance->getNDS();
 
         glUseProgram(screenShaderProgram);
@@ -1164,6 +1198,12 @@ void ScreenPanelGL::drawScreen()
 
         for (int i = 0; i < numScreens; i++)
         {
+            if (i == 1 && vCursor->cursorEnabled){
+                glUniform1i(screenShaderCursorEnableLoc, 1);
+                glUniform2f(screenShaderCursorLoc, vCursor->cursorPos[0]/256.f, vCursor->cursorPos[1]/192.f);
+            } else {
+                glUniform1f(screenShaderCursorEnableLoc, 0);
+            }
             glUniformMatrix2x3fv(screenShaderTransformULoc, 1, GL_TRUE, screenMatrix[i]);
             glDrawArrays(GL_TRIANGLES, screenKind[i] == 0 ? 0 : 2 * 3, 2 * 3);
         }

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -37,7 +37,7 @@
 
 class MainWindow;
 class EmuInstance;
-
+class Cursor;
 
 const struct { int id; float ratio; const char* label; } aspectRatios[] =
 {
@@ -59,7 +59,8 @@ public:
     virtual ~ScreenPanel();
 
     void setFilter(bool filter);
-
+    
+    Cursor* vCursor;
     void setMouseHide(bool enable, int delay);
 
     QTimer* setupMouseTimer();
@@ -222,7 +223,7 @@ private:
     GLuint screenVertexBuffer, screenVertexArray;
     GLuint screenTexture;
     GLuint screenShaderProgram;
-    GLint screenShaderTransformULoc, screenShaderScreenSizeULoc;
+    GLint screenShaderTransformULoc, screenShaderScreenSizeULoc, screenShaderCursorLoc, screenShaderCursorEnableLoc;
 
     QMutex screenSettingsLock;
     WindowInfo windowInfo;

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -81,6 +81,7 @@
 #include "CameraManager.h"
 #include "Window.h"
 #include "AboutDialog.h"
+#include "Cursor.h"
 
 using namespace melonDS;
 
@@ -257,8 +258,9 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
     }
 #endif
 
-    showOSD = windowCfg.GetBool("ShowOSD");
-
+    vCursor = new Cursor();
+    vCursor->setEmuInstance(emuInstance);
+    showOSD = windowCfg.GetBool("ShowOSD"); 
     setWindowTitle("melonDS " MELONDS_VERSION);
     setAttribute(Qt::WA_DeleteOnClose);
     setAcceptDrops(true);
@@ -612,6 +614,10 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             actShowOSD = menu->addAction("Show OSD");
             actShowOSD->setCheckable(true);
             connect(actShowOSD, &QAction::triggered, this, &MainWindow::onChangeShowOSD);
+            
+            actHideVirtualCursor = menu->addAction("Hide Virtual Cursor");
+            actHideVirtualCursor->setCheckable(true);
+            connect(actHideVirtualCursor, &QAction::triggered, this, &MainWindow::onChangeHideVirtualCursor);
         }
         {
             QMenu * menu = menubar->addMenu("Config");
@@ -956,6 +962,9 @@ void MainWindow::releaseGL()
 void MainWindow::drawScreen()
 {
     if (!panel) return;
+    vCursor->setLayout(this->getWindowConfig().GetInt("ScreenLayout"));
+    vCursor->setRotation(this->getWindowConfig().GetInt("ScreenRotation"));
+    panel->vCursor = vCursor;
     return panel->drawScreen();
 }
 
@@ -2143,6 +2152,13 @@ void MainWindow::onChangeShowOSD(bool checked)
     showOSD = checked;
     panel->osdSetEnabled(showOSD);
     windowCfg.SetBool("ShowOSD", showOSD);
+}
+
+void MainWindow::onChangeHideVirtualCursor(bool checked)
+{
+    vCursor->cursorEnabled = !checked;
+    windowCfg.SetBool("HideVirtualCursor", checked);
+
 }
 
 void MainWindow::onChangeLimitFramerate(bool checked)

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -40,6 +40,7 @@
 
 class EmuInstance;
 class EmuThread;
+class Cursor;
 
 const int kMaxRecentROMs = 10;
 
@@ -168,6 +169,7 @@ private slots:
     void onChangeIntegerScaling(bool checked);
     void onOpenNewWindow();
     void onChangeScreenFiltering(bool checked);
+    void onChangeHideVirtualCursor(bool checked);
     void onChangeShowOSD(bool checked);
     void onChangeLimitFramerate(bool checked);
     void onChangeAudioSync(bool checked);
@@ -216,7 +218,7 @@ private:
 
     EmuInstance* emuInstance;
     EmuThread* emuThread;
-
+    Cursor* vCursor;
     Config::Table& globalCfg;
     Config::Table& localCfg;
     Config::Table windowCfg;
@@ -291,6 +293,7 @@ public:
     QAction* actNewWindow;
     QAction* actScreenFiltering;
     QAction* actShowOSD;
+    QAction* actHideVirtualCursor;
     QAction* actLimitFramerate;
     QAction* actAudioSync;
 

--- a/src/frontend/qt_sdl/main_shaders.h
+++ b/src/frontend/qt_sdl/main_shaders.h
@@ -61,34 +61,34 @@ void main()
     vec4 pixel = texture(ScreenTex, fTexcoord);
     if (cursorEnable){
         //Black Outline
-        if (fTexcoord.x <= (cursorPos.x + (1.5*pixelUnit.x)) && 
-            fTexcoord.x >= (cursorPos.x - (1.5*pixelUnit.x))) {
-            if (fTexcoord.y <= (cursorPos.y + (4.5*pixelUnit.y)) && 
-                fTexcoord.y >= (cursorPos.y - (4.5*pixelUnit.y))) {
+        if (fTexcoord.x <= (cursorPos.x + (2.0*pixelUnit.x)) && 
+            fTexcoord.x >= (cursorPos.x - (1.0*pixelUnit.x))) {
+            if (fTexcoord.y <= (cursorPos.y + (5.0*pixelUnit.y)) && 
+                fTexcoord.y >= (cursorPos.y - (4.0*pixelUnit.y))) {
                 pixel = vec4(0.0, 0.0, 0.0, 1.0);
             }
         }
 
-        if (fTexcoord.y <= (cursorPos.y + (1.5*pixelUnit.y)) && 
-            fTexcoord.y >= (cursorPos.y - (1.5*pixelUnit.y))) {
-            if (fTexcoord.x <= (cursorPos.x + (4.5*pixelUnit.x)) && 
-                fTexcoord.x >= (cursorPos.x - (4.5*pixelUnit.x))) {
+        if (fTexcoord.y <= (cursorPos.y + (2.0*pixelUnit.y)) && 
+            fTexcoord.y >= (cursorPos.y - (1.0*pixelUnit.y))) {
+            if (fTexcoord.x <= (cursorPos.x + (5.0*pixelUnit.x)) && 
+                fTexcoord.x >= (cursorPos.x - (4.0*pixelUnit.x))) {
                 pixel = vec4(0.0, 0.0, 0.0, 1.0);
             }
         }
         //White Cross
-        if (fTexcoord.x <= (cursorPos.x + (0.5*pixelUnit.x)) && 
-            fTexcoord.x >= (cursorPos.x - (0.5*pixelUnit.x))) {
-            if (fTexcoord.y <= (cursorPos.y + (3.5*pixelUnit.y)) && 
-                fTexcoord.y >= (cursorPos.y - (3.5*pixelUnit.y))) {
+        if (fTexcoord.x <= (cursorPos.x + (1.0*pixelUnit.x)) && 
+            fTexcoord.x >= (cursorPos.x - (0.0*pixelUnit.x))) {
+            if (fTexcoord.y <= (cursorPos.y + (4.0*pixelUnit.y)) && 
+                fTexcoord.y >= (cursorPos.y - (3.0*pixelUnit.y))) {
                 pixel = vec4(1.0, 1.0, 1.0, 1.0);
             }
         }
 
-        if (fTexcoord.y <= (cursorPos.y + (0.5*pixelUnit.y)) && 
-            fTexcoord.y >= (cursorPos.y - (0.5*pixelUnit.y))) {
-            if (fTexcoord.x <= (cursorPos.x + (3.5*pixelUnit.x)) && 
-                fTexcoord.x >= (cursorPos.x - (3.5*pixelUnit.x))) {
+        if (fTexcoord.y <= (cursorPos.y + (1.0*pixelUnit.y)) && 
+            fTexcoord.y >= (cursorPos.y - (0.0*pixelUnit.y))) {
+            if (fTexcoord.x <= (cursorPos.x + (4.0*pixelUnit.x)) && 
+                fTexcoord.x >= (cursorPos.x - (3.0*pixelUnit.x))) {
                 pixel = vec4(1.0, 1.0, 1.0, 1.0);
             }
         }

--- a/src/frontend/qt_sdl/main_shaders.h
+++ b/src/frontend/qt_sdl/main_shaders.h
@@ -28,7 +28,7 @@ in vec2 vPosition;
 in vec3 vTexcoord;
 
 smooth out vec3 fTexcoord;
-
+out vec2 pixelUnit;
 void main()
 {
     vec4 fpos;
@@ -42,20 +42,57 @@ void main()
 
     gl_Position = fpos;
     fTexcoord = vTexcoord;
+    pixelUnit.x = 1/256.0;
+    pixelUnit.y = 1/192.0;
 }
 )";
 
 const char* kScreenFS = R"(#version 140
 
 uniform sampler2DArray ScreenTex;
-
+uniform vec2 cursorPos;
+uniform bool cursorEnable;
 smooth in vec3 fTexcoord;
-
+in vec2 pixelUnit;
 out vec4 oColor;
 
 void main()
 {
     vec4 pixel = texture(ScreenTex, fTexcoord);
+    if (cursorEnable){
+        //Black Outline
+        if (fTexcoord.x <= (cursorPos.x + (1.5*pixelUnit.x)) && 
+            fTexcoord.x >= (cursorPos.x - (1.5*pixelUnit.x))) {
+            if (fTexcoord.y <= (cursorPos.y + (4.5*pixelUnit.y)) && 
+                fTexcoord.y >= (cursorPos.y - (4.5*pixelUnit.y))) {
+                pixel = vec4(0.0, 0.0, 0.0, 1.0);
+            }
+        }
+
+        if (fTexcoord.y <= (cursorPos.y + (1.5*pixelUnit.y)) && 
+            fTexcoord.y >= (cursorPos.y - (1.5*pixelUnit.y))) {
+            if (fTexcoord.x <= (cursorPos.x + (4.5*pixelUnit.x)) && 
+                fTexcoord.x >= (cursorPos.x - (4.5*pixelUnit.x))) {
+                pixel = vec4(0.0, 0.0, 0.0, 1.0);
+            }
+        }
+        //White Cross
+        if (fTexcoord.x <= (cursorPos.x + (0.5*pixelUnit.x)) && 
+            fTexcoord.x >= (cursorPos.x - (0.5*pixelUnit.x))) {
+            if (fTexcoord.y <= (cursorPos.y + (3.5*pixelUnit.y)) && 
+                fTexcoord.y >= (cursorPos.y - (3.5*pixelUnit.y))) {
+                pixel = vec4(1.0, 1.0, 1.0, 1.0);
+            }
+        }
+
+        if (fTexcoord.y <= (cursorPos.y + (0.5*pixelUnit.y)) && 
+            fTexcoord.y >= (cursorPos.y - (0.5*pixelUnit.y))) {
+            if (fTexcoord.x <= (cursorPos.x + (3.5*pixelUnit.x)) && 
+                fTexcoord.x >= (cursorPos.x - (3.5*pixelUnit.x))) {
+                pixel = vec4(1.0, 1.0, 1.0, 1.0);
+            }
+        }
+    }
 
     oColor = vec4(pixel.rgb, 1.0);
 }


### PR DESCRIPTION
### Changes
- Added Virtual Cursor 
  - The cursor is a white crosshair with a black outline since that design is the easiest to spot during busy gameplay and over any background. It's aligned with the ds screen resolution and works in both opengl and software renderer.
  - When the mouse is in the touchscreen area, the mouse get hidden and is replaced by the virtual cursor.
  - "Hide Virtual Cursor", which has been added to the menu under the "view" section, allows the user to disable the virtual cursor and revert to the original mouse behavior
- Added Stylus Mapping
  - Added the directional stylus entries to control the stylus either with the analog sticks, or buttons. When set to analog sticks, it uses the full input range, letting gamepad users be more precise.
  - Stylus Touch lets you click the screen with a button.
  - Stylus Mod (Modifier) lets you speed up the cursor. This is mainly for quickly repositioning the cursor or doing long swipes across the ds screen for certain games.
  - Stylus Mod + (Y/A or B) lets you use macros to quickly draw in circles (counterclockwise/clockwise) and "rub the screen" respectively. Some examples of games where these are useful/necessary are Ninja Gaiden, WarioWare and Pokemon Ranger. 
  - With these controls, gamepad users should be able to play most games that use the touchscreen.
 
<img width="836" height="755" alt="Screenshot 2026-04-16 093653" src="https://github.com/user-attachments/assets/4f8a9b48-e0ed-4dda-824a-1353f78b809a" />

Closes #2485
Closes #1711
Closes #2120