### PR TITLE
Make the OpenGL (Classic) renderer work on OpenGL 3.1

### DIFF
--- a/src/GPU2D_OpenGL.cpp
+++ b/src/GPU2D_OpenGL.cpp
@@ -284,7 +284,7 @@ bool GLRenderer2D::Init()
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sz[0], sz[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
             glBindFramebuffer(GL_FRAMEBUFFER, AllBGLayerFB[l]);
-            glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, AllBGLayerTex[l], 0);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, AllBGLayerTex[l], 0);
             glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
             l++;
@@ -300,7 +300,7 @@ bool GLRenderer2D::Init()
 
     glGenFramebuffers(1, &SpriteFB);
     glBindFramebuffer(GL_FRAMEBUFFER, SpriteFB);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, SpriteTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, SpriteTex, 0);
     glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
     // generate texture to hold final (upscaled) sprites
@@ -472,14 +472,14 @@ void GLRenderer2D::SetScaleFactor(int scale)
     glBindFramebuffer(GL_FRAMEBUFFER, OBJLayerFB);
     glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, OBJLayerTex, 0, 0);
     glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, OBJLayerTex, 0, 1);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, OBJDepthTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, OBJDepthTex, 0);
     glDrawBuffers(2, fbassign2);
 
     glBindTexture(GL_TEXTURE_2D, OutputTex);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, ScreenW, ScreenH, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
     glBindFramebuffer(GL_FRAMEBUFFER, OutputFB);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, OutputTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, OutputTex, 0);
     glDrawBuffer(GL_COLOR_ATTACHMENT0);
 }
 

--- a/src/GPU3D_OpenGL.cpp
+++ b/src/GPU3D_OpenGL.cpp
@@ -357,9 +357,9 @@ void GLRenderer3D::SetRenderSettings(int scale, bool betterpolygons) noexcept
     GLenum fbassign[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
 
     glBindFramebuffer(GL_FRAMEBUFFER, MainFramebuffer);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, ColorBufferTex, 0);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, DepthBufferTex, 0);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, AttrBufferTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, ColorBufferTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, DepthBufferTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, AttrBufferTex, 0);
     glDrawBuffers(2, fbassign);
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/GPU_OpenGL.cpp
+++ b/src/GPU_OpenGL.cpp
@@ -177,7 +177,7 @@ bool GLRenderer::Init()
 
     glGenFramebuffers(1, &CaptureSyncFB);
     glBindFramebuffer(GL_FRAMEBUFFER, CaptureSyncFB);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, CaptureSyncTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, CaptureSyncTex, 0);
     glDrawBuffer(GL_COLOR_ATTACHMENT0);
     glReadBuffer(GL_COLOR_ATTACHMENT0);
 

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -900,7 +900,7 @@ bool ScreenPanelGL::createContext()
     {
         std::array<GL::Context::Version, 2> versionsToTry = {
                 GL::Context::Version{GL::Context::Profile::Core, 4, 3},
-                GL::Context::Version{GL::Context::Profile::Core, 3, 2}};
+                GL::Context::Version{GL::Context::Profile::Core, 3, 1}};
         if (windowinfo.has_value())
             if ((glContext = GL::Context::Create(*windowinfo, versionsToTry)))
                 glContext->DoneCurrent();


### PR DESCRIPTION
All shaders were already using version 140, which corresponds to OGL 3.1. None of them seem to be using any extensions introduced into the core spec in 3.2, as far as I can tell.

My first go at checking whether the CPU side was calling any functions introduced into the core standard in 3.2 turned up none. Testing showed glFramebufferTexture (which neither Mesamatrix nor [this](https://wikis.khronos.org/opengl/History_of_OpenGL#OpenGL_3.2_(2009)) mention) was a problem. Using glFramebufferTexture2D with a GL_TEXTURE_2D textarget seems to work just as well, difference being glFramebufferTexture2D does exist in OGL 3.1. Note that glFramebufferTexture**Layer** DOES exist in 3.1 (in fact, it's existed since 3.0), so those calls were fine as they were.

With this, MelonDS can use OpenGL 3.1 instead of 3.2; so Panfrost will now work.
This only affects the conventional OpenGL renderer; the compute renderer is, of course, a whole 'nother story.

Testing on radeonsi turned up no regressions (the conventional OpenGL renderer does show some artifacting in some games, but it's already there in master, I'll open an issue for that later).