### PR TITLE
Use Qt's QFile abstraction for the Platform.h file I/O functions

### DIFF
--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -281,9 +281,10 @@ u64 FileWriteFormatted(FileHandle* file, const char* fmt, ...)
 
     va_list args;
     va_start(args, fmt);
-    u64 ret = vfprintf(reinterpret_cast<FILE *>(file), fmt, args);
+    const QByteArray formatted = QString::vasprintf(fmt, args).toUtf8();
+    reinterpret_cast<QFile*>(file)->write(formatted);
     va_end(args);
-    return ret;
+    return formatted.size();
 }
 
 u64 FileLength(FileHandle* file)

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -41,14 +41,6 @@
 #include "MPInterface.h"
 #include "SPI_Firmware.h"
 
-#ifdef __WIN32__
-#include <io.h>
-#define fdopen _fdopen
-#define fseek _fseeki64
-#define ftell _ftelli64
-#define dup _dup
-#endif // __WIN32__
-
 extern CameraManager* camManager[2];
 
 extern melonDS::Net net;
@@ -135,20 +127,15 @@ FileHandle* OpenFile(const std::string& path, FileMode mode)
     }
 
     QString qpath{QString::fromStdString(path)};
+    QFile* qfile = new QFile(qpath);
 
-    std::string modeString = GetModeString(mode, QFile::exists(qpath));
     QIODevice::OpenMode qmode = GetQMode(mode);
-    QFile qfile{qpath};
-    if (qfile.open(qmode))
-    {
-        FILE* file = fdopen(dup(qfile.handle()), modeString.c_str());
-        qfile.close();
+    std::string modeString = GetModeString(mode, QFile::exists(qpath));
 
-        if (file)
-        {
-            Log(LogLevel::Debug, "Opened \"%s\" with FileMode 0x%x (effective mode \"%s\")\n", path.c_str(), mode, modeString.c_str());
-            return reinterpret_cast<FileHandle *>(file);
-        }
+    if (qfile->open(qmode))
+    {
+        Log(LogLevel::Debug, "Opened \"%s\" with FileMode 0x%x (effective mode \"%s\")\n", path.c_str(), mode, modeString.c_str());
+        return reinterpret_cast<FileHandle *>(qfile);
     }
     Log(LogLevel::Warn, "Failed to open \"%s\" with FileMode 0x%x (effective mode \"%s\")\n", path.c_str(), mode, modeString.c_str());
     return nullptr;
@@ -180,33 +167,30 @@ FileHandle* OpenLocalFile(const std::string& path, FileMode mode)
 
 bool CloseFile(FileHandle* file)
 {
-    return fclose(reinterpret_cast<FILE *>(file)) == 0;
+    QFile* qfile = reinterpret_cast<QFile*>(file);
+    qfile->close();
+    delete qfile;
+    return true;
 }
 
 bool IsEndOfFile(FileHandle* file)
 {
-    return feof(reinterpret_cast<FILE *>(file)) != 0;
+    return reinterpret_cast<QFile*>(file)->atEnd();
 }
 
 bool FileReadLine(char* str, int count, FileHandle* file)
 {
-    return fgets(str, count, reinterpret_cast<FILE *>(file)) != nullptr;
+    return reinterpret_cast<QFile*>(file)->readLine(str, count);
 }
 
 bool FileExists(const std::string& name)
 {
-    FileHandle* f = OpenFile(name, FileMode::Read);
-    if (!f) return false;
-    CloseFile(f);
-    return true;
+    return QFile::exists(QString::fromStdString(name));
 }
 
 bool LocalFileExists(const std::string& name)
 {
-    FileHandle* f = OpenLocalFile(name, FileMode::Read);
-    if (!f) return false;
-    CloseFile(f);
-    return true;
+    return QFile::exists(QString::fromStdString(GetLocalFilePath(name)));
 }
 
 bool CheckFileWritable(const std::string& filepath)
@@ -249,40 +233,45 @@ bool CheckLocalFileWritable(const std::string& name)
 
 bool FileSeek(FileHandle* file, s64 offset, FileSeekOrigin origin)
 {
-    int stdorigin;
-    switch (origin)
-    {
-        case FileSeekOrigin::Start: stdorigin = SEEK_SET; break;
-        case FileSeekOrigin::Current: stdorigin = SEEK_CUR; break;
-        case FileSeekOrigin::End: stdorigin = SEEK_END; break;
-    }
+    QFile* qfile = reinterpret_cast<QFile*>(file);
 
-    return fseek(reinterpret_cast<FILE *>(file), offset, stdorigin) == 0;
+    if (origin == FileSeekOrigin::Current)
+        offset += qfile->pos();
+    else if (origin == FileSeekOrigin::End)
+        offset += qfile->size();
+
+    return qfile->seek(offset);
 }
 
 void FileRewind(FileHandle* file)
 {
-    rewind(reinterpret_cast<FILE *>(file));
+    reinterpret_cast<QFile*>(file)->seek(0);
 }
 
 u64 FilePosition(FileHandle* file)
 {
-    return ftell(reinterpret_cast<FILE *>(file));
+    return reinterpret_cast<QFile*>(file)->pos();
 }
 
 u64 FileRead(void* data, u64 size, u64 count, FileHandle* file)
 {
-    return fread(data, size, count, reinterpret_cast<FILE *>(file));
+    qint64 read = reinterpret_cast<QFile*>(file)->read(static_cast<char*>(data), size * count);
+
+    if (read > 0) read /= (qint64) size;
+    return read;
 }
 
 bool FileFlush(FileHandle* file)
 {
-    return fflush(reinterpret_cast<FILE *>(file)) == 0;
+    return reinterpret_cast<QFile*>(file)->flush();
 }
 
 u64 FileWrite(const void* data, u64 size, u64 count, FileHandle* file)
 {
-    return fwrite(data, size, count, reinterpret_cast<FILE *>(file));
+    qint64 written = reinterpret_cast<QFile*>(file)->write(static_cast<const char*>(data), size * count);
+
+    if (written > 0) written /= (qint64) size;
+    return written;
 }
 
 u64 FileWriteFormatted(FileHandle* file, const char* fmt, ...)
@@ -299,12 +288,7 @@ u64 FileWriteFormatted(FileHandle* file, const char* fmt, ...)
 
 u64 FileLength(FileHandle* file)
 {
-    FILE* stdfile = reinterpret_cast<FILE *>(file);
-    long pos = ftell(stdfile);
-    fseek(stdfile, 0, SEEK_END);
-    long len = ftell(stdfile);
-    fseek(stdfile, pos, SEEK_SET);
-    return len;
+    return reinterpret_cast<QFile*>(file)->size();
 }
 
 void Log(LogLevel level, const char* fmt, ...)


### PR DESCRIPTION
melonDS is currently rather pointlessly opening files through Qt and then duplicating and reopening the file with the stdio file functions, there's not really any reason to do this anymore since the core no longer works with plain `FILE*`s, and since we're using Qt for the frontend, I feel it would be more appropriate to also have Qt's file abstractions handle this.

Avoiding this hack also means we don't need to worry about Windows's stdio weirdness and might hopefully also improve robustness of melonDS's file operations a bit.