### PR TITLE
Prevent entering fullscreen while a dialog is open (fixes input lockup)

### DIFF
--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2199,6 +2199,11 @@ void MainWindow::toggleFullscreen()
 {
     if (!isFullScreen())
     {
+        if (QApplication::activeModalWidget() || QApplication::activePopupWidget())
+        {
+            // Block entering fullscreen while a dialog/popup is active
+            return;
+        }
         showFullScreen();
         if (hasMenu)
             menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working


### PR DESCRIPTION
Fixes an issue where the window becomes unresponsive after toggling fullscreen while a dialog is open (mostly seen via controller hotkey).

### Reproduce:
- Open a dialog (Config → Input and hotkeys works)
- Enter fullscreen (controller hotkey)
- Close the dialog while still fullscreen
- Exit fullscreen

The window then can't be clicked and behaves like a popup still has focus.

### Fix:
Block entering fullscreen if a modal dialog or popup is active.

Exiting fullscreen is still allowed so you don't get stuck.

Fixes #1504