### PR TITLE
Fix SPU output buffer leak

### DIFF
--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -226,6 +226,12 @@ SPU::SPU(melonDS::NDS& nds, AudioBitDepth bitdepth, AudioInterpolation interpola
 
 SPU::~SPU()
 {
+    if (OutputBuffer != nullptr)
+    {
+        free(OutputBuffer);
+        OutputBuffer = nullptr;
+    }
+
     Platform::Mutex_Free(AudioLock);
     AudioLock = nullptr;
     blip_delete(BlipLeft);


### PR DESCRIPTION
### Abbreviated valgrind output

```text
HEAP SUMMARY:
    in use at exit: ...

8,192 bytes in 1 blocks are definitely lost in loss record 381 of 382
   at 0x8D83828: malloc
   by 0x2E30F0: melonDS::SPU::InitOutput() (SPU.cpp:1085)
   by 0x2E315C: melonDS::SPU::Reset() (SPU.cpp:239)
   by 0x2D98DE: melonDS::NDS::Reset() (NDS.cpp:546)
   by 0x1AEBDE: EmuInstance::updateConsole() (EmuInstance.cpp:1352)
   by 0x1B09C6: EmuInstance::bootToMenu(QString&) (EmuInstance.cpp:1461)
   by 0x1B6403: EmuThread::handleMessages() (EmuThread.cpp:581)
   by 0x1B823F: EmuThread::run() (EmuThread.cpp:445)

LEAK SUMMARY:
   definitely lost: 8,344 bytes in 2 blocks
   indirectly lost: 148 bytes in 2 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 103,561 bytes in 1,134 blocks
```

The run contains additional Qt/input-method leak noise, but the `SPU::InitOutput()` allocation is an independent definite leak.

The allocation Valgrind reports is in `SPU::InitOutput()`:

```cpp
OutputBuffer = (s16*) malloc(2 * newBufferSize * 2);
```

For the tested 48 kHz output sample rate, `newBufferSize` becomes 2048, so the allocation size is:

```text
2 * 2048 * 2 = 8192 bytes
```

That exactly matches Valgrind's `8,192 bytes in 1 blocks are definitely lost` report.

`SPU::Stop()` is not an ownership cleanup path. It only clears and reuses the existing buffer:

```cpp
memset(OutputBuffer, 0, 2*OutputBufferSize*2);
```

The owning cleanup path is `SPU::~SPU()`. Before the fix, the destructor freed `AudioLock`, `BlipLeft`, and `BlipRight`, but did not free `OutputBuffer`. Therefore the last `OutputBuffer` allocation made by `InitOutput()` remained definitely lost when the `NDS`/`SPU` object was destroyed.