### PR TITLE
Use BranchOptimizations in ARMJIT::SetMaxBlockSize

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -511,7 +511,7 @@ void ARMJIT::SetJITArgs(JITArgs args) noexcept
 
 void ARMJIT::SetMaxBlockSize(int size) noexcept
 {
-    SetJITArgs(JITArgs{static_cast<unsigned>(size), LiteralOptimizations, LiteralOptimizations, FastMemory});
+    SetJITArgs(JITArgs{static_cast<unsigned>(size), LiteralOptimizations, BranchOptimizations, FastMemory});
 }
 
 void ARMJIT::SetLiteralOptimizations(bool enabled) noexcept


### PR DESCRIPTION
SetJITArgs in ARMJIT::SetMaxBlockSize used LiteralOptimizations in place of BranchOptimizations which seems like a mistake. 