### PR TITLE
Soul Link Milestone 2: add hardcoded TCP read endpoint

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -60,6 +60,9 @@ set(SOURCES_QT_SDL
 
     LANDialog.cpp
     NetplayDialog.cpp
+
+    SoulLinkServer.h
+    SoulLinkServer.cpp
 )
 
 option(USE_QT6 "Use Qt 6 instead of Qt 5" ON)

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -49,6 +49,7 @@
 #include "main.h"
 
 #include "NDSCart/CartSD.h"
+#include "SoulLinkServer.h"
 
 using std::make_unique;
 using std::pair;
@@ -133,6 +134,9 @@ EmuInstance::EmuInstance(int inst) : deleting(false),
 
     emuThread = new EmuThread(this);
 
+    soulLinkServer = new SoulLinkServer(this);
+    soulLinkServer->start();
+
     numWindows = 0;
     mainWindow = nullptr;
     for (int i = 0; i < kMaxWindows; i++)
@@ -162,6 +166,9 @@ EmuInstance::~EmuInstance()
     emuThread->wait();
     delete emuThread;
     emuThread = nullptr;
+
+    delete soulLinkServer;
+    soulLinkServer = nullptr;
 
     net.UnregisterInstance(instanceID);
 

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -81,6 +81,8 @@ enum
 bool isRightModKey(QKeyEvent* event);
 int getEventKeyVal(QKeyEvent* event);
 
+class SoulLinkServer;
+
 class EmuInstance
 {
 public:
@@ -264,6 +266,8 @@ private:
     bool deleting;
 
     int instanceID;
+
+    SoulLinkServer* soulLinkServer;
 
     EmuThread* emuThread;
 

--- a/src/frontend/qt_sdl/SoulLinkServer.cpp
+++ b/src/frontend/qt_sdl/SoulLinkServer.cpp
@@ -1,0 +1,80 @@
+/*
+    Soul Link DS — Milestone 2: hardcoded read endpoint
+*/
+
+#include "SoulLinkServer.h"
+#include "EmuInstance.h"
+#include "NDS.h"
+
+#include <QTcpSocket>
+#include <cstdio>
+#include <cstring>
+
+// ARM9 address to read. 0x02000000 is the start of main RAM — always present
+// once a ROM is loaded, and its contents change as the game runs.
+// Replace with a game-specific address (e.g., party HP in HG/SS) once confirmed.
+static constexpr melonDS::u32 kWatchAddr = 0x02000000;
+static constexpr int kWatchLen = 16;
+
+SoulLinkServer::SoulLinkServer(EmuInstance* emu, QObject* parent)
+    : QObject(parent)
+    , server(new QTcpServer(this))
+    , emuInstance(emu)
+{
+    connect(server, &QTcpServer::newConnection, this, &SoulLinkServer::onNewConnection);
+}
+
+SoulLinkServer::~SoulLinkServer()
+{
+    server->close();
+}
+
+void SoulLinkServer::start(quint16 port)
+{
+    if (!server->listen(QHostAddress::LocalHost, port))
+    {
+        fprintf(stderr, "[SoulLink] Failed to listen on port %d: %s\n",
+                port, server->errorString().toUtf8().constData());
+    }
+    else
+    {
+        fprintf(stderr, "[SoulLink] Listening on 127.0.0.1:%d\n", port);
+    }
+}
+
+void SoulLinkServer::onNewConnection()
+{
+    QTcpSocket* client = server->nextPendingConnection();
+    if (!client) return;
+
+    // deleteLater keeps Qt happy if the client disconnects before we write
+    connect(client, &QTcpSocket::disconnected, client, &QTcpSocket::deleteLater);
+
+    melonDS::NDS* nds = emuInstance->getNDS();
+    if (!nds || !nds->MainRAM)
+    {
+        client->write("ERR no ROM loaded\n");
+        client->disconnectFromHost();
+        return;
+    }
+
+    // ARM9 address → offset into MainRAM
+    melonDS::u32 offset = kWatchAddr - 0x02000000;
+
+    // Snapshot the bytes. A torn read across a frame boundary is acceptable
+    // for this diagnostic read — we're not writing to RAM here.
+    melonDS::u8 buf[kWatchLen];
+    memcpy(buf, nds->MainRAM + offset, kWatchLen);
+
+    // Format: "BYTES addr=0x02000000 len=16 data=aabbcc...\n"
+    QString line = QString("BYTES addr=0x%1 len=%2 data=")
+                       .arg(kWatchAddr, 8, 16, QChar('0'))
+                       .arg(kWatchLen);
+    for (int i = 0; i < kWatchLen; i++)
+        line += QString("%1").arg(buf[i], 2, 16, QChar('0'));
+    line += "\n";
+
+    client->write(line.toUtf8());
+    client->flush();
+    client->disconnectFromHost();
+}

--- a/src/frontend/qt_sdl/SoulLinkServer.h
+++ b/src/frontend/qt_sdl/SoulLinkServer.h
@@ -1,0 +1,31 @@
+/*
+    Soul Link DS — Milestone 2: hardcoded read endpoint
+    Listens on localhost TCP. When a client connects, returns hex bytes
+    at a hardcoded RAM address, then closes the connection.
+    Verify with: nc 127.0.0.1 8765
+*/
+
+#pragma once
+
+#include <QObject>
+#include <QTcpServer>
+
+namespace melonDS { class NDS; }
+class EmuInstance;
+
+class SoulLinkServer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SoulLinkServer(EmuInstance* emu, QObject* parent = nullptr);
+    ~SoulLinkServer();
+
+    void start(quint16 port = 8765);
+
+private slots:
+    void onNewConnection();
+
+private:
+    QTcpServer* server;
+    EmuInstance* emuInstance;
+};


### PR DESCRIPTION
Adds SoulLinkServer, a QTcpServer that listens on localhost:8765. When a client connects, it reads 16 bytes from offset 0x02000000 (start of main RAM) and returns them as a hex line, then closes.

This proves the socket→MainRAM pipeline end-to-end with no game logic yet. Verify with: nc 127.0.0.1 8765 while a ROM is running.

The address is a placeholder; Milestone 3 will replace it with a generic WATCH/EVENT protocol.