### PR TITLE
ARDatabaseDAT: initialize ARCode::Parent when loading from .DAT

### DIFF
--- a/src/ARDatabaseDAT.cpp
+++ b/src/ARDatabaseDAT.cpp
@@ -280,6 +280,7 @@ bool ARDatabaseDAT::LoadCheatCodes(EntryInfo& info, ARDatabaseEntry& entry)
             }
 
             ARCode code;
+            code.Parent = curcat;
             code.Name = itemname;
             code.Description = itemdesc;
             code.Enabled = !!(itemflags & (1<<24));


### PR DESCRIPTION
When parsing a code item inside a category in `ARDatabaseDAT::LoadCheatCodes`, the `ARCode` struct is built without setting its `Parent` pointer (the field is a raw `ARCodeCat*` with no default member initializer). The neighboring `ARCodeCat` case a few lines above already sets `.Parent = &entry.RootCat` explicitly. This commit applies the same fix to `ARCode`, pointing it at the current category.

Found by cppcheck (`uninitvar` at `src/ARDatabaseDAT.cpp:298`).