### PR TITLE
FATStorage: initialize LastModified for newly-tracked files

### DIFF
--- a/src/FATStorage.cpp
+++ b/src/FATStorage.cpp
@@ -511,6 +511,7 @@ void FATStorage::ExportDirectory(const std::string& path, const std::string& out
                 entry.Path = fullpath;
                 entry.IsReadOnly = (info.fattrib & AM_RDO) != 0;
                 entry.Size = info.fsize;
+                entry.LastModified = 0;
                 entry.LastModifiedInternal = (info.fdate << 16) | info.ftime;
 
                 FileIndex[entry.Path] = entry;


### PR DESCRIPTION
In `FATStorage::ImportDirectory` (the `else` branch around `src/FATStorage.cpp:510-516`), a new `FileIndexEntry` is created with `Path`, `IsReadOnly`, `Size`, and `LastModifiedInternal` set, but `LastModified` (s64) is left uninitialized. The field is only assigned later if the file actually goes through `ExportFile` (line 538). If a later run reaches the load-time check at line 951 (`if (chk.LastModified != lastmodified_raw) import = true;`) before any export sets it, the comparison reads garbage and can falsely trigger a re-import.

Fix: initialize `LastModified = 0` at creation, same shape as the surrounding fields.

Found by cppcheck (`uninitvar` at `src/FATStorage.cpp:516`).