### PR TITLE
Netplay: fix off-by-one in PlayerAddress bounds check

### DIFF
--- a/src/net/Netplay.cpp
+++ b/src/net/Netplay.cpp
@@ -277,7 +277,7 @@ void StartMirror(const Player* player)
 
 u32 PlayerAddress(int id)
 {
-    if (id < 0 || id > 16) return 0;
+    if (id < 0 || id >= 16) return 0;
 
     u32 ret = Players[id].Address;
     if (ret == 0x0100007F) ret = HostAddress;


### PR DESCRIPTION
`PlayerAddress()` (`src/net/Netplay.cpp:278-285`) guards against out-of-range player ids with `id > 16`, but the `Players` array is declared `Player Players[16]` (`src/net/Netplay.cpp:48`), so valid indices are `0..15`. The current check lets `id == 16` slip through and read `Players[16]`, which is out of bounds.

Fix: change `id > 16` to `id >= 16`.

Found by cppcheck (`arrayIndexOutOfBoundsCond` at `src/net/Netplay.cpp:282`).