### PR TITLE
DSP_HLE/UcodeBase: mark inherited methods as 'override'

### DIFF
--- a/src/DSP_HLE/UcodeBase.h
+++ b/src/DSP_HLE/UcodeBase.h
@@ -46,8 +46,8 @@ public:
     u16 RecvData(u8 index);
     virtual void SendData(u8 index, u16 val);
 
-    u16 DMAChan0GetSrcHigh();
-    u16 DMAChan0GetDstHigh();
+    u16 DMAChan0GetSrcHigh() override;
+    u16 DMAChan0GetDstHigh() override;
     u16 AHBMGetDmaChannel(u16 index) const;
     u16 AHBMGetDirection(u16 index) const;
     u16 AHBMGetUnitSize(u16 index) const;
@@ -63,7 +63,7 @@ public:
     void AHBMWrite16(u32 addr, u16 val);
     void AHBMWrite32(u32 addr, u32 val);
 
-    u16 GetSemaphore() const;
+    u16 GetSemaphore() const override;
     void SetSemaphore(u16 val);
     void ClearSemaphore(u16 val);
     void MaskSemaphore(u16 val);


### PR DESCRIPTION
`UcodeBase::DMAChan0GetSrcHigh`, `UcodeBase::DMAChan0GetDstHigh` and `UcodeBase::GetSemaphore` are overrides of pure virtual methods declared in `DSPInterface` (`src/DSi_DSP.h:72-73,58`), but were not marked `override`. They were already dispatched polymorphically via the vtable (signatures match), so this is purely a maintainability cleanup — adding `override` makes the relationship explicit and lets the compiler catch silent breakage if `DSPInterface`'s signatures ever drift.

Scope kept narrow on purpose: only the three methods flagged by cppcheck (`duplInheritedMember`). A broader sweep would mark every overridden method in `UcodeBase` and could land later if welcome.

Found by cppcheck (`duplInheritedMember` in `src/DSP_HLE/UcodeBase.{h,cpp}`).