### PR TITLE
Mark resource-owning classes non-copyable

### DIFF
--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -157,6 +157,10 @@ class DSi_I2CHost
 public:
     DSi_I2CHost(melonDS::DSi& dsi);
     ~DSi_I2CHost();
+
+    DSi_I2CHost(const DSi_I2CHost&) = delete;
+    DSi_I2CHost& operator=(const DSi_I2CHost&) = delete;
+
     void Reset();
     void DoSavestate(Savestate* file);
 

--- a/src/FIFO.h
+++ b/src/FIFO.h
@@ -119,6 +119,9 @@ public:
         delete[] Entries;
     }
 
+    DynamicFIFO(const DynamicFIFO&) = delete;
+    DynamicFIFO& operator=(const DynamicFIFO&) = delete;
+
 
     void Clear()
     {

--- a/src/Wifi.h
+++ b/src/Wifi.h
@@ -160,6 +160,10 @@ public:
 
     Wifi(melonDS::NDS& nds);
     ~Wifi();
+
+    Wifi(const Wifi&) = delete;
+    Wifi& operator=(const Wifi&) = delete;
+
     void Reset();
     void DoSavestate(Savestate* file);
 


### PR DESCRIPTION
`Wifi`, `DSi_I2CHost` and the `DynamicFIFO<T>` template all manage heap-allocated state and have a user-defined destructor that frees it (`delete[] Entries`, owned `DSi_BPTWL`/`DSi_Camera*`, etc.), but none of them declares a copy constructor or a copy assignment operator. The implicit ones copy the owned pointers by value, which would lead to a double-free or a UAF as soon as one of the copies goes out of scope.

C++17's guaranteed copy elision currently hides this on the existing call sites — most notably the aggregate-init of `DynamicFIFO<u8> Mailbox[9]` in `DSi_NWifi` — so the issue is latent rather than active. The safety net is one accidental `auto x = y;` or pass-by-value away from biting, though.

This patch declares the copy ctor and copy assignment as `= delete` on each class. If a future change ever needs copy semantics, the compiler will refuse it and force the author to think about it, instead of silently producing a UAF.

Build was clean before/after, confirming no existing call site relies on the implicit copies.

Found by cppcheck (`noCopyConstructor` + `noOperatorEq` on `Wifi`, `DSi_I2CHost`, `DynamicFIFO<>`).