### PR TITLE
Fix tearing in hidden BG FMV playback

### DIFF
--- a/src/GPU2D_OpenGL.cpp
+++ b/src/GPU2D_OpenGL.cpp
@@ -42,6 +42,7 @@ GLRenderer2D::GLRenderer2D(melonDS::GPU2D& gpu2D, GLRenderer& parent)
     : Renderer2D(gpu2D), Parent(parent)
 {
     ScaleFactor = 0;
+    DeferredLayerPrerenderDirty = 0;
 }
 
 #define glDefaultTexParams(target) \
@@ -430,6 +431,7 @@ void GLRenderer2D::Reset()
     memset(BGVRAMRange, 0xFF, sizeof(BGVRAMRange));
 
     LayerConfigDirty = true;
+    DeferredLayerPrerenderDirty = 0;
 
     LastSpriteLine = 0;
     memset(OAM, 0, sizeof(OAM));
@@ -565,6 +567,10 @@ void GLRenderer2D::UpdateAndRender(int line)
         (GPU2D.EVY != EVY))
         comp_dirty = true;
 
+    const u8 register_layer_pre_dirty = layer_pre_dirty;
+    const u8 visible_layers = (LayerEnable | GPU2D.LayerEnable) & 0xF;
+    layer_pre_dirty |= DeferredLayerPrerenderDirty & visible_layers;
+
     // check if VRAM was modified, and flatten it as needed
 
     static_assert(VRAMDirtyGranularity == 512);
@@ -639,6 +645,13 @@ void GLRenderer2D::UpdateAndRender(int line)
                 layer_pre_dirty |= (1 << layer);
         }
     }
+
+    // Hidden BG layers can be streamed while another layer is displayed.
+    // Upload their VRAM now, but defer prerendering until they become visible.
+    const u8 inactive_layer_pre_dirty =
+        (layer_pre_dirty & ~register_layer_pre_dirty) & ~visible_layers;
+    DeferredLayerPrerenderDirty |= inactive_layer_pre_dirty;
+    layer_pre_dirty &= ~inactive_layer_pre_dirty;
 
     if (layer_pre_dirty)
         comp_dirty = true;
@@ -765,6 +778,8 @@ void GLRenderer2D::UpdateAndRender(int line)
 
             PrerenderLayer(layer);
         }
+
+        DeferredLayerPrerenderDirty &= ~layer_pre_dirty;
     }
 
     if (SpriteDirty)

--- a/src/GPU2D_OpenGL.h
+++ b/src/GPU2D_OpenGL.h
@@ -198,6 +198,7 @@ private:
     u32 BGVRAMRange[4][4];
 
     bool LayerConfigDirty;
+    u8 DeferredLayerPrerenderDirty;
 
     int LastSpriteLine;
     u16 OAM[512];


### PR DESCRIPTION
This fixes FMV tearing in games that stream video data into an inactive BG layer, then later switch that BG on-screen.

The OpenGL renderer could prerender a hidden BG layer while the game was still updating it, leaving the cached BG texture with a mix of old and new frame data. This change still uploads VRAM changes normally, but defers rebuilding the BG texture until the layer is actually visible. That avoids building an FMV's BG texture from a half-updated video frame.

This partially addresses #2555. It affects several games that use Mobiclip FMVs. I tested it with Kingdom Hearts 358/2 Days and Ni no Kuni.

I also looked into Pokémon Black, but that seems to be a different case where it updates BG layers that are already visible. Fixing that safely would need a larger change, since games can also update visible BGs mid-frame for other effects.