### PR TITLE
BUILD.md: fix Qt 6 dev package names for Ubuntu 22.04

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,7 +9,7 @@
    * Ubuntu:
      * All versions: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev libarchive-dev libenet-dev libzstd-dev libfaad-dev`
      * 24.04: `sudo apt install qt6-{base,base-private,multimedia,svg}-dev`
-     * 22.04: `sudo apt install qtbase6-dev qtbase6-private-dev qtmultimedia6-dev libqt6svg6-dev`
+     * 22.04: `sudo apt install qt6-base-dev qt6-base-private-dev qt6-multimedia-dev libqt6svg6-dev`
      * Older versions: `sudo apt install qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev`  
        Also add `-DUSE_QT6=OFF` to the first CMake command below.
    * Fedora: `sudo dnf install gcc-c++ cmake extra-cmake-modules SDL2-devel libarchive-devel enet-devel libzstd-devel faad2-devel qt6-{qtbase,qtbase-private,qtmultimedia,qtsvg}-devel wayland-devel`


### PR DESCRIPTION
The Qt 6 packages currently listed for Ubuntu 22.04 in [BUILD.md](BUILD.md) do not exist in the 22.04 repositories, so `apt install` of that line fails with `Unable to locate package qtbase6-dev`.

The actual package names in Ubuntu 22.04 (jammy) use a `qt6-` prefix, matching what the file already documents for 24.04:

| Listed in BUILD.md | Actual package in 22.04 |
| --- | --- |
| `qtbase6-dev` | `qt6-base-dev` |
| `qtbase6-private-dev` | `qt6-base-private-dev` |
| `qtmultimedia6-dev` | `qt6-multimedia-dev` |
| `libqt6svg6-dev` | `libqt6svg6-dev` (unchanged — correct) |

`libqt6svg6-dev` is intentionally left as-is, since `qt6-svg-dev` is not available on 22.04 (only on 24.04).

Verified on a fresh Ubuntu 22.04.5 LTS install: the updated line installs cleanly and melonDS builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)