### PR TITLE
Disable portable mode by default on Windows

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -195,7 +195,7 @@ target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::LibArchive PkgC
 target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
 
 if (WIN32)
-    option(PORTABLE "Make a portable build that looks for its configuration in the current directory" ON)
+    option(PORTABLE "Make a portable build that looks for its configuration in the current directory" OFF)
 
     if (PORTABLE)
         target_compile_definitions(melonDS PRIVATE WIN32_PORTABLE)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -44,6 +44,12 @@
 #include <csignal>
 #endif
 
+#ifdef _WIN32
+// Windows builds used to have portable enabled by default, in order to not break people's existing setups,
+// this will make it check for melonDS.toml in the executable directory and use it if it already exists.
+#define PORTABLE_CONFIG_COMPAT
+#endif
+
 #include <SDL2/SDL.h>
 
 #include "OpenGLSupport.h"
@@ -198,17 +204,29 @@ void pathInit()
     {
         emuDirectory = portabledir.absolutePath();
     }
+#ifdef PORTABLE_CONFIG_COMPAT
+    else if (QFile::exists(appdirpath + QDir::separator() + "melonDS.toml") || QFile::exists(appdirpath + QDir::separator() + "melonDS.ini"))
+    {
+        emuDirectory = appdirpath;
+    }
+#endif
     else
     {
         // If no overrides are specified, use the default path.
-#if defined(__WIN32__) && defined(WIN32_PORTABLE)
+#if defined(_WIN32) && defined(WIN32_PORTABLE)
         emuDirectory = appdirpath;
 #else
         QString confdir;
         QDir config(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation));
+#ifdef _WIN32
+        // For some reason the config path returned above already has "/melonDS" suffixed to it on Windows.
+        config.mkdir(".");
+        emuDirectory = config.path();
+#else
         config.mkdir("melonDS");
         confdir = config.absolutePath() + QDir::separator() + "melonDS";
         emuDirectory = confdir;
+#endif
 #endif
     }
 }


### PR DESCRIPTION
Makes melonDS on Windows behave like it does in regard to its config directory on other platforms by default. The config file will now go in `C:\Users\<username>\AppData\Local\melonDS`.

I've added a check for whether the config file already exists in the executable path for backwards compatibility so this doesn't break people's pre-existing setups.

The motivation for this is that a lot of users get confused by the default behavior, either from not knowing that melonDS needs to be stored in a writable directory, or from presumably file synchronization tools marking paths in e.g. the user Documents folder as read-only, and melonDS suddenly failing to write its config file. Local AppData should always be a safe path to write into, so this will lead to less surprising error-prone behavior for users.

Remember that if you do want a portable version anyway, you can make a `portable` directory next to the executable and it will be used instead of the AppData path.