### PR TITLE
Move fast-forward mute option to audio settings

### DIFF
--- a/src/frontend/qt_sdl/AudioSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.cpp
@@ -68,6 +68,7 @@ AudioSettingsDialog::AudioSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     ui->slVolume->blockSignals(state);
 
     ui->chkSyncDSiVolume->setChecked(oldDSiSync);
+    ui->cbMuteFastForward->setChecked(cfg.GetBool("MuteFastForward"));
 
     // Setup volume slider accordingly
     if (emuActive && emuInstance->getNDS()->ConsoleType == 1)
@@ -159,6 +160,7 @@ void AudioSettingsDialog::onConsoleReset()
 void AudioSettingsDialog::on_AudioSettingsDialog_accepted()
 {
     auto& cfg = emuInstance->getGlobalConfig();
+    cfg.SetBool("MuteFastForward", ui->cbMuteFastForward->isChecked());
     cfg.SetQString("Mic.Device", ui->cbMic->currentText());
     cfg.SetInt("Mic.InputType", grpMicMode->checkedId());
     cfg.SetQString("Mic.WavPath", ui->txtMicWavPath->text());

--- a/src/frontend/qt_sdl/AudioSettingsDialog.ui
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>482</width>
-    <height>301</height>
+    <height>321</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -60,14 +60,24 @@
        </widget>
       </item>
       <item row="3" column="1">
-        <widget class="QCheckBox" name="chkSyncDSiVolume">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Synchronizes the output volume with the DSi hardware volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Sync with DSi volume</string>
-         </property>
-        </widget>
+       <widget class="QCheckBox" name="chkSyncDSiVolume">
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Synchronizes the output volume with the DSi hardware volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Sync with DSi volume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="cbMuteFastForward">
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mutes audio output while fast-forward is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Mute audio while fast forwarding</string>
+        </property>
+       </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
@@ -200,6 +210,7 @@
   <tabstop>cbBitDepth</tabstop>
   <tabstop>slVolume</tabstop>
   <tabstop>chkSyncDSiVolume</tabstop>
+  <tabstop>cbMuteFastForward</tabstop>
   <tabstop>rbMicNone</tabstop>
   <tabstop>rbMicExternal</tabstop>
   <tabstop>rbMicNoise</tabstop>

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
@@ -39,7 +39,6 @@ InterfaceSettingsDialog::InterfaceSettingsDialog(QWidget* parent) : QDialog(pare
     ui->spinMouseHideSeconds->setEnabled(ui->cbMouseHide->isChecked());
     ui->spinMouseHideSeconds->setValue(cfg.GetInt("Mouse.HideSeconds"));
     ui->cbPauseLostFocus->setChecked(cfg.GetBool("PauseLostFocus"));
-    ui->cbMuteFastForward->setChecked(cfg.GetBool("MuteFastForward"));
     ui->spinTargetFPS->setValue(cfg.GetDouble("TargetFPS"));
     ui->spinFFW->setValue(cfg.GetDouble("FastForwardFPS"));
     ui->spinSlow->setValue(cfg.GetDouble("SlowmoFPS"));
@@ -119,7 +118,6 @@ void InterfaceSettingsDialog::done(int r)
         cfg.SetBool("Mouse.Hide", ui->cbMouseHide->isChecked());
         cfg.SetInt("Mouse.HideSeconds", ui->spinMouseHideSeconds->value());
         cfg.SetBool("PauseLostFocus", ui->cbPauseLostFocus->isChecked());
-        cfg.SetBool("MuteFastForward", ui->cbMuteFastForward->isChecked());
 
         double val = ui->spinTargetFPS->value();
         if (val == 0.0) cfg.SetDouble("TargetFPS", 0.0001);

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.ui
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.ui
@@ -90,13 +90,6 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QCheckBox" name="cbMuteFastForward">
-        <property name="text">
-         <string>Mute audio while fast forwarding</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This moves the “Mute audio while fast forwarding” checkbox from Interface settings to Audio settings.

The MuteFastForward config option and runtime audio behavior already exist; this change only exposes the setting in the Audio output section, where it fits better.