### PR TITLE
wifi: don't auto power down the transceiver when power save is disabled

### DIFF
--- a/src/Wifi.cpp
+++ b/src/Wifi.cpp
@@ -393,7 +393,13 @@ void Wifi::SetIRQ13()
 {
     SetIRQ(13);
 
-    if ((IOPORT(W_ModeWEP) & 0x7) != 3)
+    // auto power-down should only happen in automatic power saving mode (0).
+    // it must not happen when power saving is disabled (mode 2): stations
+    // running in that mode (eg. dswifi in infrastructure mode) don't service
+    // IRQ13/IRQ15, so a power-down triggered by the one-shot W_BeaconCount2
+    // countdown (armed at 0xFFFF = ~67s) would turn the transceiver off
+    // with nothing ever waking it up again
+    if ((IOPORT(W_ModeWEP) & 0x7) == 0)
     {
         if (!(IOPORT(W_PowerTX) & (1<<1)))
         {


### PR DESCRIPTION
Fixes #2680

dswifi in infrastructure mode runs with power saving disabled (`W_MODE_WEP`sleep mode 2), but arms the one-shot `W_BeaconCount2` countdown at 0xFFFF TUs (≈67s) during init. `SetIRQ13()` exempted only sleep mode 3 from auto power-down, so when the countdown ran out the transceiver was powered off and since stations with power saving disabled don't service IRQ13/IRQ15, nothing ever woke it back up. All wifi traffic silently died ~67s after init.

This restricts the auto power-down to automatic power saving mode (0). Real hardware does not power down in mode 2 (verified with the repro ROM from the issue: dies at ~67s on melonDS, runs indefinitely on a real DS).

I wasn't sure whether mode 1 should also auto-sleep happy to adjust if the intended semantics are different.

Tested: repro ROM from #2680 on macOS, master build radio stays alive well past the 67s mark (>4 min soak); unpatched build dies on schedule.