### PR TITLE
Feature: Native 1:1 PS4 Touchpad Mapping for DS Touchscreen

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -253,14 +253,14 @@ void EmuThread::run()
 
             // process input and hotkeys
             emuInstance->nds->SetKeyMask(emuInstance->inputMask);
-		// --- PS4 TOUCHPAD NATIVE INTEGRATION ---
+		// --- GAMEPAD TOUCHPAD NATIVE INTEGRATION ---
 SDL_PumpEvents(); // Refresh SDL's internal hardware state
 
 // Open the primary controller (0). If it is already open, this just borrows the connection.
 SDL_GameController* pad = SDL_GameControllerOpen(0);
 if (pad) {
     if (SDL_GameControllerGetNumTouchpads(pad) > 0) {
-        static bool ps4WasTouching = false;
+        static bool padWasTouching = false;
         Uint8 touchState = 0;
         float px = 0.0f, py = 0.0f, pressure = 0.0f;
 
@@ -275,17 +275,17 @@ if (pad) {
             // Clamp boundaries to prevent emulator crashes
             if (emuInstance->touchX > 255) emuInstance->touchX = 255;
             if (emuInstance->touchY > 191) emuInstance->touchY = 191;
-            ps4WasTouching = true;
-        } else if (ps4WasTouching) {
+            padWasTouching = true;
+        } else if (padWasTouching) {
             // Finger was lifted this exact frame
             emuInstance->isTouching = false;
-            ps4WasTouching = false;
+            padWasTouching = false;
         }
     }
     // Drop our temporary connection to prevent memory leaks
     SDL_GameControllerClose(pad); 
 }
-// --- END PS4 TOUCHPAD INTEGRATION ---
+// --- END GAMEPAD TOUCHPAD INTEGRATION ---
             if (emuInstance->isTouching)
                 emuInstance->nds->TouchScreen(emuInstance->touchX, emuInstance->touchY);
             else

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -253,7 +253,39 @@ void EmuThread::run()
 
             // process input and hotkeys
             emuInstance->nds->SetKeyMask(emuInstance->inputMask);
+		// --- PS4 TOUCHPAD NATIVE INTEGRATION ---
+SDL_PumpEvents(); // Refresh SDL's internal hardware state
 
+// Open the primary controller (0). If it is already open, this just borrows the connection.
+SDL_GameController* pad = SDL_GameControllerOpen(0);
+if (pad) {
+    if (SDL_GameControllerGetNumTouchpads(pad) > 0) {
+        static bool ps4WasTouching = false;
+        Uint8 touchState = 0;
+        float px = 0.0f, py = 0.0f, pressure = 0.0f;
+
+        // Read the absolute position of the primary finger (0) on the primary pad (0)
+        SDL_GameControllerGetTouchpadFinger(pad, 0, 0, &touchState, &px, &py, &pressure);
+
+        if (touchState != 0) {
+            emuInstance->isTouching = true;
+            emuInstance->touchX = static_cast<int>(px * 255.0f + 0.5f);
+            emuInstance->touchY = static_cast<int>(py * 191.0f + 0.5f);
+
+            // Clamp boundaries to prevent emulator crashes
+            if (emuInstance->touchX > 255) emuInstance->touchX = 255;
+            if (emuInstance->touchY > 191) emuInstance->touchY = 191;
+            ps4WasTouching = true;
+        } else if (ps4WasTouching) {
+            // Finger was lifted this exact frame
+            emuInstance->isTouching = false;
+            ps4WasTouching = false;
+        }
+    }
+    // Drop our temporary connection to prevent memory leaks
+    SDL_GameControllerClose(pad); 
+}
+// --- END PS4 TOUCHPAD INTEGRATION ---
             if (emuInstance->isTouching)
                 emuInstance->nds->TouchScreen(emuInstance->touchX, emuInstance->touchY);
             else

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -340,7 +340,6 @@ int main(int argc, char** argv)
     {
         printf("SDL couldn't init rumble\n");
     }
-    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
     if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
     {

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -340,6 +340,8 @@ int main(int argc, char** argv)
     {
         printf("SDL couldn't init rumble\n");
     }
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
     if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
     {
         printf("SDL couldn't init joystick\n");


### PR DESCRIPTION
The Concept
Playing touch-heavy games on a monitor can feel clunky when using a mouse to mimic quick stylus taps. This PR introduces native, absolute 1:1 coordinate mapping using a DualShock 4 controller's built-in touchpad via Bluetooth.

This implementation takes heavy inspiration from 3DS emulation fork Azahar, which has proven how seamless and natural absolute touchpad integration feels for dual-screen emulation.

Implementation Details
Instead of building a complex event loop, this leverages SDL2's internal state tracker directly within the EmuThread.cpp loop, right before emuInstance->isTouching is evaluated:

    Uses SDL_GameControllerGetTouchpadFinger() to instantly query the absolute position of the primary finger.

    Converts SDL's normalized decimal coordinates (0.0 to 1.0) into the rigid 256x192 pixel space of the DS bottom screen using standard aspect compression.

    Automatically clamps boundaries to prevent out-of-bounds emulator crashes.

    Seamlessly hands control back to the mouse upon finger lift (padWasTouching flag) so users can switch between mouse and touchpad dynamically.

Testing Environment

    OS: Windows 11

    Hardware: HP ProBook 445 G8 (Ryzen 5 5600U, 16GB RAM)

    Controller: Original DualShock 4 via Bluetooth

    Build Toolchain: MSYS2 / MinGW-w64 (Compiled via CMake + Ninja)

A Note on Development
Transparency note: I am not a career C++ software engineer, so I utilized an AI assistant to help draft the precise SDL2 API calls and coordinate math. However, I have fully compiled the source code from scratch, resolved the MSYS2 toolchain dependencies, and extensively tested the compiled .exe on hardware to verify the touch inputs register flawlessly without performance dips.