### PR TITLE
Add Libretro Slang Shader / Filters Support (Frontend UI)

### DIFF
--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -55,7 +55,7 @@ jobs:
             install_deps: >
               pkg_add -v cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-qtbase qt6-qtmultimedia qt6-qtsvg sdl2 libarchive zstd
-              enet faad glslang spirv-cross
+              enet faad glslang spirv-cross spirv-tools
 
     name: ${{ matrix.os_name }} / ${{ matrix.arch }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -116,8 +116,13 @@ jobs:
           name: melonDS-${{ matrix.os }}-${{ matrix.arch }}
           path: build/melonDS
 
-      - name: Rename binary for Release
-        run: mv build/melonDS build/melonDS-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Package Release
+        run: |
+          mkdir -p package/res
+          cp build/melonDS package/melonDS
+          cp -r res/slang-shaders package/res/
+          cd package
+          zip -r ../melonDS-${{ matrix.os }}-${{ matrix.arch }}.zip *
 
       - name: Continuous Release
         uses: softprops/action-gh-release@v2
@@ -125,4 +130,4 @@ jobs:
         with:
           tag_name: continuous
           name: Latest Development Release
-          files: build/melonDS-${{ matrix.os }}-${{ matrix.arch }}
+          files: melonDS-${{ matrix.os }}-${{ matrix.arch }}.zip

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -96,7 +96,7 @@ jobs:
           cmake --install SPIRV-Cross/build
 
           git clone --depth 1 https://github.com/KhronosGroup/glslang.git
-          cmake -S glslang -B glslang/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/pkg
+          cmake -S glslang -B glslang/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/pkg -DENABLE_OPT=OFF
           cmake --build glslang/build
           cmake --install glslang/build
 

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -29,7 +29,7 @@ jobs:
             install_deps: >
               pkg install -y cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-base qt6-multimedia qt6-svg sdl2 libarchive zstd enet
-              faad2 glslang spirv-cross
+              faad2 glslang spirv-cross zip
 
           - os: netbsd
             os_name: NetBSD
@@ -48,14 +48,14 @@ jobs:
             install_deps: >
               pkgin -y install cmake extra-cmake-modules pkgconf
               ninja-build qt6-qtbase qt6-qtmultimedia qt6-qtsvg SDL2
-              libarchive zstd enet faad2 git
+              libarchive zstd enet faad2 git zip
 
           - os: openbsd
             os_name: OpenBSD
             install_deps: >
               pkg_add -v cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-qtbase qt6-qtmultimedia qt6-qtsvg sdl2 libarchive zstd
-              enet faad glslang spirv-cross spirv-tools
+              enet faad glslang spirv-cross spirv-tools zip
 
     name: ${{ matrix.os_name }} / ${{ matrix.arch }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         name: Check out sources
+        with:
+          submodules: recursive
 
       - name: Start ${{ matrix.os_name }} VM
         uses: jenseng/dynamic-uses@v1

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -48,7 +48,7 @@ jobs:
             install_deps: >
               pkgin -y install cmake extra-cmake-modules pkgconf
               ninja-build qt6-qtbase qt6-qtmultimedia qt6-qtsvg SDL2
-              libarchive zstd enet faad2 glslang spirv-cross
+              libarchive zstd enet faad2 git
 
           - os: openbsd
             os_name: OpenBSD
@@ -86,6 +86,19 @@ jobs:
 
       - name: Install dependencies
         run: ${{ matrix.install_deps }}
+
+      - name: Build missing Khronos dependencies (NetBSD fallback)
+        if: matrix.os == 'netbsd'
+        run: |
+          git clone --depth 1 https://github.com/KhronosGroup/SPIRV-Cross.git
+          cmake -S SPIRV-Cross -B SPIRV-Cross/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/pkg -DSPIRV_CROSS_SHARED=ON
+          cmake --build SPIRV-Cross/build
+          cmake --install SPIRV-Cross/build
+
+          git clone --depth 1 https://github.com/KhronosGroup/glslang.git
+          cmake -S glslang -B glslang/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/pkg
+          cmake --build glslang/build
+          cmake --install glslang/build
 
       - name: Configure
         run: >

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - ci/*
+      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -28,7 +29,7 @@ jobs:
             install_deps: >
               pkg install -y cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-base qt6-multimedia qt6-svg sdl2 libarchive zstd enet
-              faad2
+              faad2 glslang spirv-cross
 
           - os: netbsd
             os_name: NetBSD
@@ -47,15 +48,14 @@ jobs:
             install_deps: >
               pkgin -y install cmake extra-cmake-modules pkgconf
               ninja-build qt6-qtbase qt6-qtmultimedia qt6-qtsvg SDL2
-              libarchive zstd enet faad2
+              libarchive zstd enet faad2 glslang spirv-cross
 
           - os: openbsd
             os_name: OpenBSD
             install_deps: >
               pkg_add -v cmake kf6-extra-cmake-modules pkgconf ninja
               qt6-qtbase qt6-qtmultimedia qt6-qtsvg sdl2 libarchive zstd
-              enet faad
-
+              enet faad glslang spirv-cross
 
     name: ${{ matrix.os_name }} / ${{ matrix.arch }}
     runs-on: ubuntu-latest
@@ -64,41 +64,52 @@ jobs:
         shell: ${{ matrix.os }} {0}
 
     steps:
-    - uses: actions/checkout@v6
-      name: Check out sources
+      - uses: actions/checkout@v6
+        name: Check out sources
 
-    - name: Start ${{ matrix.os_name }} VM
-      uses: jenseng/dynamic-uses@v1
-      with:
-        uses: vmactions/${{ matrix.os }}-vm@v1
-        # As we are using multiple steps, we need to use NFS to sync the
-        # workspace between host and VM, as with the default, rsync, the
-        # workspace is only synced before and after the setup VM step.
-        with: >
-          {
-            "arch": ${{ matrix.arch }},
-            "envs": "MELONDS_GIT_BRANCH MELONDS_GIT_HASH
-                     MELONDS_BUILD_PROVIDER",
-            "prepare": ${{ toJSON(matrix.prepare_vm) }},
-            "sync": "nfs",
-            "usesh": "true",
-          }
+      - name: Start ${{ matrix.os_name }} VM
+        uses: jenseng/dynamic-uses@v1
+        with:
+          uses: vmactions/${{ matrix.os }}-vm@v1
+          # As we are using multiple steps, we need to use NFS to sync the
+          # workspace between host and VM, as with the default, rsync, the
+          # workspace is only synced before and after the setup VM step.
+          with: >
+            {
+              "arch": ${{ matrix.arch }},
+              "envs": "MELONDS_GIT_BRANCH MELONDS_GIT_HASH
+                       MELONDS_BUILD_PROVIDER",
+              "prepare": ${{ toJSON(matrix.prepare_vm) }},
+              "sync": "nfs",
+              "usesh": "true",
+            }
 
-    - name: Install dependencies
-      run: ${{ matrix.install_deps }}
+      - name: Install dependencies
+        run: ${{ matrix.install_deps }}
 
-    - name: Configure
-      run: >
-        cmake -S $GITHUB_WORKSPACE -B /tmp/build -G Ninja
-        -DMELONDS_EMBED_BUILD_INFO=ON
+      - name: Configure
+        run: >
+          cmake -S $GITHUB_WORKSPACE -B /tmp/build -G Ninja
+          -DMELONDS_EMBED_BUILD_INFO=ON
 
-    - name: Build
-      run: |
-        cmake --build /tmp/build
-        cp -RP /tmp/build $GITHUB_WORKSPACE/
+      - name: Build
+        run: |
+          cmake --build /tmp/build
+          cp -RP /tmp/build $GITHUB_WORKSPACE/
 
-    - name: Upload binary
-      uses: actions/upload-artifact@v7
-      with:
-        name: melonDS-${{ matrix.os }}-${{ matrix.arch }}
-        path: build/melonDS
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: melonDS-${{ matrix.os }}-${{ matrix.arch }}
+          path: build/melonDS
+
+      - name: Rename binary for Release
+        run: mv build/melonDS build/melonDS-${{ matrix.os }}-${{ matrix.arch }}
+
+      - name: Continuous Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
+        with:
+          tag_name: continuous
+          name: Latest Development Build
+          files: build/melonDS-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -111,5 +111,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest Development Build
+          name: Latest
           files: build/melonDS-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - ci/*
-      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -125,11 +124,3 @@ jobs:
           cp -r res/slang-shaders package/res/
           cd package
           zip -r ../melonDS-${{ matrix.os }}-${{ matrix.arch }}.zip *
-
-      - name: Continuous Release
-        uses: softprops/action-gh-release@v2
-        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
-        with:
-          tag_name: continuous
-          name: Latest Development Release
-          files: melonDS-${{ matrix.os }}-${{ matrix.arch }}.zip

--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -124,5 +124,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest
+          name: Latest Development Release
           files: build/melonDS-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -117,5 +117,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest
+          name: Latest Development Release
           files: macOS-universal.zip

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -57,6 +57,8 @@ jobs:
         shell: bash
         run: |
           cd build/release-mac-${{ matrix.arch }}
+          mkdir -p melonDS.app/Contents/MacOS/res
+          cp -r ../../res/slang-shaders melonDS.app/Contents/MacOS/res/
           zip -r -y ../../macOS-${{ matrix.arch }}.zip melonDS.app
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -59,8 +59,8 @@ jobs:
         shell: bash
         run: |
           cd build/release-mac-${{ matrix.arch }}
-          mkdir -p melonDS.app/Contents/MacOS/res
-          cp -r ../../res/slang-shaders melonDS.app/Contents/MacOS/res/
+          mkdir -p melonDS.app/Contents/Resources/res
+          cp -r ../../res/slang-shaders melonDS.app/Contents/Resources/res/
           zip -r -y ../../macOS-${{ matrix.arch }}.zip melonDS.app
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - ci/*
-      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -116,10 +115,3 @@ jobs:
       #         name: |
       #           macOS-x86_64
       #           macOS-arm64
-      - name: Continuous Release
-        uses: softprops/action-gh-release@v2
-        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
-        with:
-          tag_name: continuous
-          name: Latest Development Release
-          files: macOS-universal.zip

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - ci/*
+      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -104,10 +105,17 @@ jobs:
           name: macOS-universal
           path: macOS-universal.zip
           archive: false
-#     - name: Clean up architecture-specific artifacts
-#       uses: geekyeggo/delete-artifact@v4
-#       with:
-#         failOnError: false
-#         name: |
-#           macOS-x86_64
-#           macOS-arm64
+      #     - name: Clean up architecture-specific artifacts
+      #       uses: geekyeggo/delete-artifact@v4
+      #       with:
+      #         failOnError: false
+      #         name: |
+      #           macOS-x86_64
+      #           macOS-arm64
+      - name: Continuous Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
+        with:
+          tag_name: continuous
+          name: Latest Development Build
+          files: macOS-universal.zip

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -117,5 +117,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest Development Build
+          name: Latest
           files: macOS-universal.zip

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: Install dependencies for package building
         run: |
           brew install autoconf automake autoconf-archive libtool python-setuptools

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - ci/*
+      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -30,37 +31,44 @@ jobs:
     runs-on: ${{ matrix.arch.runner }}
 
     steps:
-    - uses: actions/checkout@v6
-      name: Check out sources
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
-          qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev
-    - name: Configure
-      run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
-    - name: Build
-      run: |
-        cmake --build build
-        DESTDIR=AppDir cmake --install build
-    - uses: actions/upload-artifact@v7
-      with:
-        name: melonDS-ubuntu-${{ matrix.arch.name }}
-        path: AppDir/usr/bin/melonDS
-    - name: Fetch AppImage tools
-      run: |
-        wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${{ matrix.arch.name }}.AppImage
-        wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-${{ matrix.arch.name }}.AppImage
-        chmod a+x linuxdeploy-*.AppImage
-    - name: Build the AppImage
-      env:
-        EXTRA_PLATFORM_PLUGINS: libqwayland-egl.so;libqwayland-generic.so
-        EXTRA_QT_PLUGINS: waylandcompositor
-        QMAKE: /usr/lib/qt6/bin/qmake
-      run: |
-        ./linuxdeploy-${{ matrix.arch.name }}.AppImage --appdir AppDir --plugin qt --output appimage
-    - uses: actions/upload-artifact@v7
-      with:
-        name: melonDS-appimage-${{ matrix.arch.name }}
-        path: melonDS*.AppImage
-        archive: false
+      - uses: actions/checkout@v6
+        name: Check out sources
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
+            qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev glslang-dev spirv-cross
+      - name: Configure
+        run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
+      - name: Build
+        run: |
+          cmake --build build
+          DESTDIR=AppDir cmake --install build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: melonDS-ubuntu-${{ matrix.arch.name }}
+          path: AppDir/usr/bin/melonDS
+      - name: Fetch AppImage tools
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${{ matrix.arch.name }}.AppImage
+          wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-${{ matrix.arch.name }}.AppImage
+          chmod a+x linuxdeploy-*.AppImage
+      - name: Build the AppImage
+        env:
+          EXTRA_PLATFORM_PLUGINS: libqwayland-egl.so;libqwayland-generic.so
+          EXTRA_QT_PLUGINS: waylandcompositor
+          QMAKE: /usr/lib/qt6/bin/qmake
+        run: |
+          ./linuxdeploy-${{ matrix.arch.name }}.AppImage --appdir AppDir --plugin qt --output appimage
+      - uses: actions/upload-artifact@v7
+        with:
+          name: melonDS-appimage-${{ matrix.arch.name }}
+          path: melonDS*.AppImage
+          archive: false
+      - name: Continuous Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
+        with:
+          tag_name: continuous
+          name: Latest Development Build
+          files: melonDS*.AppImage

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -38,6 +38,17 @@ jobs:
           sudo apt update
           sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
             qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev glslang-dev spirv-cross
+      - name: Build Khronos dependencies (Ubuntu 22.04 apt fallback)
+        run: |
+          git clone --depth 1 https://github.com/KhronosGroup/SPIRV-Cross.git
+          cmake -S SPIRV-Cross -B SPIRV-Cross/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DSPIRV_CROSS_SHARED=ON
+          sudo cmake --build SPIRV-Cross/build
+          sudo cmake --install SPIRV-Cross/build
+
+          git clone --depth 1 https://github.com/KhronosGroup/glslang.git
+          cmake -S glslang -B glslang/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPT=OFF
+          sudo cmake --build glslang/build
+          sudo cmake --install glslang/build
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
       - name: Build
@@ -70,5 +81,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest
+          name: Latest Development Release
           files: melonDS*.AppImage

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -70,5 +70,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest Development Build
+          name: Latest
           files: melonDS*.AppImage

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - ci/*
-      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -78,10 +77,3 @@ jobs:
           name: melonDS-appimage-${{ matrix.arch.name }}
           path: melonDS*.AppImage
           archive: false
-      - name: Continuous Release
-        uses: softprops/action-gh-release@v2
-        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
-        with:
-          tag_name: continuous
-          name: Latest Development Release
-          files: melonDS*.AppImage

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         name: Check out sources
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - ci/*
+      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -31,30 +32,37 @@ jobs:
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
-    - name: Check out sources
-      uses: actions/checkout@v6
-    - name: Restore vcpkg cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
-        restore-keys: vcpkg-${{ matrix.arch.name }}-windows-
-    - name: Set up vcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgJsonGlob: vcpkg.json
-    - name: Build
-      uses: lukka/run-cmake@v10
-      with:
-        configurePreset: release-windows-${{ matrix.arch.name }}
-        configurePresetAdditionalArgs: "['-DENABLE_DEBUG_DEPS=OFF', '-DMELONDS_EMBED_BUILD_INFO=ON']"
-        buildPreset: release-windows-${{ matrix.arch.name }}
-    - uses: actions/upload-artifact@v7
-      with:
-        name: melonDS-windows-${{ matrix.arch.name }}
-        path: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe
-    - name: Save vcpkg cache
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ github.workspace }}/vcpkg_cache
-        key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
+      - name: Check out sources
+        uses: actions/checkout@v6
+      - name: Restore vcpkg cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
+          restore-keys: vcpkg-${{ matrix.arch.name }}-windows-
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: vcpkg.json
+      - name: Build
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: release-windows-${{ matrix.arch.name }}
+          configurePresetAdditionalArgs: "['-DENABLE_DEBUG_DEPS=OFF', '-DMELONDS_EMBED_BUILD_INFO=ON']"
+          buildPreset: release-windows-${{ matrix.arch.name }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: melonDS-windows-${{ matrix.arch.name }}
+          path: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe
+      - name: Save vcpkg cache
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
+      - name: Continuous Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
+        with:
+          tag_name: continuous
+          name: Latest Development Build
+          files: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -50,10 +50,17 @@ jobs:
           configurePreset: release-windows-${{ matrix.arch.name }}
           configurePresetAdditionalArgs: "['-DENABLE_DEBUG_DEPS=OFF', '-DMELONDS_EMBED_BUILD_INFO=ON']"
           buildPreset: release-windows-${{ matrix.arch.name }}
+      - name: Package Release
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path package
+          Copy-Item -Path .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe -Destination package\
+          Copy-Item -Path .\res -Destination package\res -Recurse
+          Compress-Archive -Path package\* -DestinationPath melonDS-windows-${{ matrix.arch.name }}.zip
       - uses: actions/upload-artifact@v7
         with:
           name: melonDS-windows-${{ matrix.arch.name }}
-          path: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe
+          path: melonDS-windows-${{ matrix.arch.name }}.zip
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
         with:
@@ -65,4 +72,4 @@ jobs:
         with:
           tag_name: continuous
           name: Latest Development Release
-          files: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe
+          files: melonDS-windows-${{ matrix.arch.name }}.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -64,5 +64,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest Development Build
+          name: Latest
           files: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -64,5 +64,5 @@ jobs:
         if: github.ref == 'refs/heads/feature/frontend-modern-filters'
         with:
           tag_name: continuous
-          name: Latest
+          name: Latest Development Release
           files: .\build\release-windows-${{ matrix.arch.name }}\melonDS.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: Restore vcpkg cache
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - ci/*
-      - feature/frontend-modern-filters
   pull_request:
     branches:
       - master
@@ -68,10 +67,3 @@ jobs:
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-${{ matrix.arch.name }}-windows-${{ hashFiles('vcpkg.json') }}
-      - name: Continuous Release
-        uses: softprops/action-gh-release@v2
-        if: github.ref == 'refs/heads/feature/frontend-modern-filters'
-        with:
-          tag_name: continuous
-          name: Latest Development Release
-          files: melonDS-windows-${{ matrix.arch.name }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ CMakeCache.txt
 freebios/FreeBIOS_Data.h
 freebios/bios*
 freebios/build/
+
+vcpkg/
+vcpkg_installed/
+vcpkg_fedora.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ CMakeCache.txt
 freebios/FreeBIOS_Data.h
 freebios/bios*
 freebios/build/
-
-vcpkg/
-vcpkg_installed/
-vcpkg_fedora.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "res/slang-shaders"]
+	path = res/slang-shaders
+	url = https://github.com/libretro/slang-shaders.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,4 +109,6 @@ add_subdirectory(src)
 
 if (BUILD_QT_SDL)
     add_subdirectory(src/frontend/qt_sdl)
+
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/res DESTINATION bin)
 endif()

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -7,6 +7,15 @@ set(SOURCES_QT_SDL
     main_shaders.h
     Screen.cpp
     Window.cpp
+    SlangPreset.cpp
+    SlangPreset.h
+    ShaderManager.cpp
+    ShaderManager.h
+    ShaderParser.cpp
+    ShaderParser.h
+    ShaderConfigDialog.cpp
+    ShaderConfigDialog.h
+    FrontendShader.h
     EmuInstance.cpp
     EmuInstanceAudio.cpp
     EmuInstanceInput.cpp
@@ -190,9 +199,22 @@ if (USE_QT6)
 else()
     target_include_directories(melonDS PUBLIC ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
+
+find_package(glslang CONFIG REQUIRED)
+find_package(spirv_cross_core CONFIG REQUIRED)
+find_package(spirv_cross_glsl CONFIG REQUIRED)
+
 target_link_libraries(melonDS PRIVATE core)
 target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::LibArchive PkgConfig::Zstd PkgConfig::Faad)
 target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
+
+target_link_libraries(melonDS PRIVATE
+    glslang::glslang
+    glslang::SPIRV
+    glslang::glslang-default-resource-limits
+    spirv-cross-core
+    spirv-cross-glsl
+)
 
 if (WIN32)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" ON)

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -72,6 +72,7 @@ DefaultList<int> DefaultInts =
     {"Instance*.Gdb.ARM9.Port", 3333},
 #endif
     {"LAN.HostNumPlayers", 16},
+    {"Instance*.Window*.Filter2D", 0},
 };
 
 RangeList IntRanges =
@@ -91,6 +92,7 @@ RangeList IntRanges =
     {"Instance*.Window*.ScreenAspectBot", {0, AspectRatiosNum-1}},
     {"MP.AudioMode", {0, 2}},
     {"LAN.HostNumPlayers", {2, 16}},
+    {"Instance*.Window*.Filter2D", {0, 2}},
 };
 
 DefaultList<bool> DefaultBools =
@@ -118,7 +120,9 @@ DefaultList<std::string> DefaultStrings =
 {
     {"DLDI.ImagePath",                  "dldi.bin"},
     {"DSi.SD.ImagePath",                "dsisd.bin"},
-    {"Instance*.Firmware.Username",     "melonDS"}
+    {"Instance*.Firmware.Username",     "melonDS"},
+    {"Instance*.Window*.ShaderPresetPath", ""},
+    {"Instance*.Window*.ShaderParams", ""}
 };
 
 DefaultList<double> DefaultDoubles =

--- a/src/frontend/qt_sdl/FrontendShader.h
+++ b/src/frontend/qt_sdl/FrontendShader.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "SlangPreset.h"
+#include <string>
+
+struct FrontendShader {
+    std::string name;
+    std::string author;
+    std::string description;
+    std::string path; // Full filesystem path to the .slangp file
+    SlangPreset preset;
+};

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -17,9 +17,11 @@
 */
 
 #include <string.h>
+#include <sstream>
 
 #include <optional>
 #include <cmath>
+#include <algorithm>
 
 #include <QPaintEvent>
 #include <QPainter>
@@ -38,11 +40,13 @@
 #include "GPU3D_OpenGL.h"
 #include "Platform.h"
 #include "Config.h"
+#include "Window.h"
 
 #include "main_shaders.h"
 #include "OSD_shaders.h"
 #include "font.h"
 #include "version.h"
+#include "SlangPreset.h"
 
 using namespace melonDS;
 
@@ -1021,6 +1025,66 @@ void ScreenPanelGL::initOpenGL()
     logoTexture = tex;
 
     transferLayout();
+    shaderManager = std::make_unique<ShaderManager>();
+
+    MainWindow* mainWin = (MainWindow*)parentWidget();
+    if (mainWin) {
+        std::string presetPathStr = mainWin->getWindowConfig().GetString("ShaderPresetPath");
+        if (!presetPathStr.empty()) {
+            std::vector<std::string> presetPaths;
+            std::stringstream ss(presetPathStr);
+            std::string part;
+            while (std::getline(ss, part, '+')) {
+                if (!part.empty()) presetPaths.push_back(part);
+            }
+            
+            SlangPreset combined;
+            bool first = true;
+            for (const auto& pPath : presetPaths) {
+                SlangPreset preset;
+                if (preset.load(pPath)) {
+                    if (first) {
+                        combined = preset;
+                        first = false;
+                    } else {
+                        combined.appendPassesFrom(preset);
+                    }
+                }
+            }
+            
+            if (!first) {
+                shaderManager->LoadPreset(combined);
+                
+                std::string savedParamsStr = mainWin->getWindowConfig().GetString("ShaderParams");
+                std::stringstream ssOuter(savedParamsStr);
+                std::string presetBlock;
+                while (std::getline(ssOuter, presetBlock, '#')) {
+                    size_t pipePos = presetBlock.find('|');
+                    if (pipePos != std::string::npos) {
+                        std::string pPath = presetBlock.substr(0, pipePos);
+                        for (const auto& sp : presetPaths) {
+                            if (pPath == sp) {
+                                std::string paramsStr = presetBlock.substr(pipePos + 1);
+                                std::stringstream ssInner(paramsStr);
+                                std::string paramPair;
+                                while (std::getline(ssInner, paramPair, ';')) {
+                                    size_t eqPos = paramPair.find('=');
+                                    if (eqPos != std::string::npos) {
+                                        try {
+                                            float val = std::stof(paramPair.substr(eqPos + 1));
+                                            shaderManager->SetParameter(paramPair.substr(0, eqPos), val);
+                                        } catch(...) {}
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     glInited = true;
 }
 
@@ -1030,6 +1094,8 @@ void ScreenPanelGL::deinitOpenGL()
     if (!glInited) return;
 
     glContext->MakeCurrent();
+
+    shaderManager.reset();
 
     glDeleteTextures(1, &screenTexture);
 
@@ -1132,6 +1198,7 @@ void ScreenPanelGL::drawScreen()
         glUniform2f(screenShaderScreenSizeULoc, w / factor, h / factor);
 
         void* topbuf; void* bottombuf;
+        GLuint rawTex = screenTexture;
         if (nds->GPU.GetFramebuffers(&topbuf, &bottombuf))
         {
             // if we're doing a regular render, use the provided framebuffers
@@ -1147,11 +1214,51 @@ void ScreenPanelGL::drawScreen()
         }
         else
         {
-            GLuint texid = *(GLuint*)topbuf;
-
-            glActiveTexture(GL_TEXTURE0);
-            glBindTexture(GL_TEXTURE_2D_ARRAY, texid);
+            rawTex = *(GLuint*)topbuf;
         }
+
+        GLuint finalTex = rawTex;
+        int outW = 256, outH = 192;
+
+        if (shaderManager) {
+            glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+
+            int screenW = w;
+            int screenH = h;
+            if (numScreens > 0) {
+                screenW = 0;
+                screenH = 0;
+                for (int i = 0; i < numScreens; ++i) {
+                    float m0 = screenMatrix[i][0];
+                    float m1 = screenMatrix[i][1];
+                    float m2 = screenMatrix[i][2];
+                    float m3 = screenMatrix[i][3];
+
+                    float dx_x = m0 * 256.0f;
+                    float dy_x = m1 * 256.0f;
+                    int curW = static_cast<int>(std::round(std::sqrt(dx_x*dx_x + dy_x*dy_x)));
+
+                    float dx_y = m2 * 192.0f;
+                    float dy_y = m3 * 192.0f;
+                    int curH = static_cast<int>(std::round(std::sqrt(dx_y*dx_y + dy_y*dy_y)));
+
+                    screenW = std::max(screenW, curW);
+                    screenH = std::max(screenH, curH);
+                }
+                if (screenW <= 0) screenW = w;
+                if (screenH <= 0) screenH = h;
+            }
+
+            finalTex = shaderManager->Process(rawTex, 256, 192, screenW, screenH, outW, outH);
+
+            glBindFramebuffer(GL_FRAMEBUFFER, 0);
+            glViewport(0, 0, w, h);
+            glUseProgram(screenShaderProgram);
+            glUniform2f(screenShaderScreenSizeULoc, w / factor, h / factor);
+        }
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, finalTex);
 
         screenSettingsLock.lock();
 

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -33,7 +33,7 @@
 #include "glad/glad.h"
 #include "ScreenLayout.h"
 #include "duckstation/gl/context.h"
-
+#include "ShaderManager.h"
 
 class MainWindow;
 class EmuInstance;
@@ -71,6 +71,7 @@ public:
     void osdAddMessage(unsigned int color, const char* msg);
 
     virtual void drawScreen() {}// = 0;
+    virtual ShaderManager* getShaderManager() { return nullptr; }
 
 private slots:
     void onScreenLayoutChanged();
@@ -202,6 +203,8 @@ public:
 
     void drawScreen() override;
 
+    ShaderManager* getShaderManager() override { return shaderManager.get(); }
+
     GL::Context* getContext() { return glContext.get(); }
 
     void transferLayout();
@@ -218,6 +221,8 @@ private:
 
     std::unique_ptr<GL::Context> glContext;
     bool glInited;
+
+    std::unique_ptr<ShaderManager> shaderManager;
 
     GLuint screenVertexBuffer, screenVertexArray;
     GLuint screenTexture;

--- a/src/frontend/qt_sdl/ShaderConfigDialog.cpp
+++ b/src/frontend/qt_sdl/ShaderConfigDialog.cpp
@@ -1,0 +1,324 @@
+#include "ShaderConfigDialog.h"
+#include "Window.h"
+#include "Config.h"
+#include <QHBoxLayout>
+#include <QSplitter>
+#include <QGroupBox>
+#include <QSlider>
+#include <QFormLayout>
+#include <QFrame>
+#include <QEvent>
+#include <QPushButton>
+
+ShaderConfigDialog::ShaderConfigDialog(ShaderManager* manager, const std::vector<FrontendShader>& presets, MainWindow* mainWindow)
+    : QDialog(mainWindow), m_shaderManager(manager), m_presets(presets), m_mainWindow(mainWindow) {
+    setWindowTitle("Shader Configuration");
+    setMinimumSize(700, 500);
+
+    if (m_mainWindow) {
+        std::string savedParamsStr = m_mainWindow->getWindowConfig().GetString("ShaderParams");
+        std::stringstream ssOuter(savedParamsStr);
+        std::string presetBlock;
+        while (std::getline(ssOuter, presetBlock, '#')) {
+            size_t pipePos = presetBlock.find('|');
+            if (pipePos != std::string::npos) {
+                std::string presetPath = presetBlock.substr(0, pipePos);
+                std::string paramsStr = presetBlock.substr(pipePos + 1);
+                std::stringstream ssInner(paramsStr);
+                std::string paramPair;
+                while (std::getline(ssInner, paramPair, ';')) {
+                    size_t eqPos = paramPair.find('=');
+                    if (eqPos != std::string::npos) {
+                        try {
+                            float val = std::stof(paramPair.substr(eqPos + 1));
+                            m_savedParameters[presetPath][paramPair.substr(0, eqPos)] = val;
+                        } catch(...) {}
+                    }
+                }
+            }
+        }
+    }
+
+    // Restore previously saved parameter values from config
+    setupUI();
+    loadPresets();
+}
+
+bool ShaderConfigDialog::eventFilter(QObject* obj, QEvent* event) {
+    if (event->type() == QEvent::Wheel && qobject_cast<QSlider*>(obj)) {
+        return true; // Ignore wheel events on sliders
+    }
+    return QDialog::eventFilter(obj, event);
+}
+
+void ShaderConfigDialog::setupUI() {
+    QHBoxLayout* mainLayout = new QHBoxLayout(this);
+    QSplitter* splitter = new QSplitter(Qt::Horizontal, this);
+
+    m_presetList = new QListWidget(this);
+    connect(m_presetList, &QListWidget::itemClicked, this, &ShaderConfigDialog::onPresetSelected);
+    connect(m_presetList, &QListWidget::itemChanged, this, &ShaderConfigDialog::onPresetChanged);
+    connect(m_presetList, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* current, QListWidgetItem* previous) {
+        if (current) onPresetSelected(current);
+    });
+    splitter->addWidget(m_presetList);
+
+    QWidget* rightWidget = new QWidget(this);
+    QVBoxLayout* rightLayout = new QVBoxLayout(rightWidget);
+
+    m_titleLabel = new QLabel("<b>Shader Title</b>", this);
+    m_titleLabel->setStyleSheet("font-size: 16px;");
+    m_authorLabel = new QLabel("Author: Unknown", this);
+    m_descLabel = new QLabel("No description available.", this);
+    m_descLabel->setWordWrap(true);
+
+    m_resetButton = new QPushButton("Reset to Default", this);
+    m_resetButton->setVisible(false);
+    connect(m_resetButton, &QPushButton::clicked, this, &ShaderConfigDialog::onResetParameters);
+
+    QHBoxLayout* titleLayout = new QHBoxLayout();
+    titleLayout->addWidget(m_titleLabel);
+    titleLayout->addStretch();
+    titleLayout->addWidget(m_resetButton);
+
+    rightLayout->addLayout(titleLayout);
+    rightLayout->addWidget(m_authorLabel);
+    rightLayout->addWidget(m_descLabel);
+
+    QFrame* line = new QFrame(this);
+    line->setFrameShape(QFrame::HLine);
+    line->setFrameShadow(QFrame::Sunken);
+    rightLayout->addWidget(line);
+
+    QScrollArea* scrollArea = new QScrollArea(this);
+    scrollArea->setWidgetResizable(true);
+    m_paramsWidget = new QWidget(this);
+    m_paramsLayout = new QVBoxLayout(m_paramsWidget);
+    m_paramsLayout->setAlignment(Qt::AlignTop);
+    scrollArea->setWidget(m_paramsWidget);
+    rightLayout->addWidget(scrollArea);
+
+    splitter->addWidget(rightWidget);
+    splitter->setStretchFactor(1, 1);
+
+    mainLayout->addWidget(splitter);
+}
+
+void ShaderConfigDialog::loadPresets() {
+    m_presetList->blockSignals(true);
+
+    std::string currentPathsStr = "";
+    if (m_mainWindow) {
+        currentPathsStr = m_mainWindow->getWindowConfig().GetString("ShaderPresetPath");
+    }
+
+    std::vector<std::string> currentPaths;
+    {
+        std::stringstream ss(currentPathsStr);
+        std::string part;
+        while (std::getline(ss, part, '+')) {
+            if (!part.empty()) currentPaths.push_back(part);
+        }
+    }
+
+    QListWidgetItem* nearestItem = new QListWidgetItem("Nearest (Default)", m_presetList);
+    nearestItem->setFlags(nearestItem->flags() | Qt::ItemIsUserCheckable);
+    nearestItem->setCheckState(currentPaths.empty() ? Qt::Checked : Qt::Unchecked);
+
+    for (const auto& feShader : m_presets) {
+        QListWidgetItem* item = new QListWidgetItem(QString::fromStdString(feShader.name), m_presetList);
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        bool isChecked = std::find(currentPaths.begin(), currentPaths.end(), feShader.path) != currentPaths.end();
+        item->setCheckState(isChecked ? Qt::Checked : Qt::Unchecked);
+
+        if (isChecked) {
+            updateDetails(feShader);
+        }
+    }
+
+    if (currentPaths.empty()) {
+        m_titleLabel->setText("<b>Nearest (Default)</b>");
+        m_authorLabel->setText("Author: N/A");
+        m_descLabel->setText("Standard nearest-neighbor scaling without filters.");
+    }
+
+    m_presetList->blockSignals(false);
+}
+
+void ShaderConfigDialog::onPresetSelected(QListWidgetItem* item) {
+    int index = m_presetList->row(item);
+
+    if (index == 0) {
+        m_titleLabel->setText("<b>Nearest (Default)</b>");
+        m_authorLabel->setText("Author: N/A");
+        m_descLabel->setText("Standard nearest-neighbor scaling without filters.");
+        clearLayout(m_paramsLayout);
+        m_resetButton->setVisible(false);
+    } else {
+        const auto& feShader = m_presets[index - 1];
+        updateDetails(feShader);
+    }
+}
+
+void ShaderConfigDialog::onPresetChanged(QListWidgetItem* item) {
+    SlangPreset combined;
+    bool anyShaderChecked = false;
+    std::string pathsStr = "";
+
+    for (int i = 1; i < m_presetList->count(); ++i) {
+        QListWidgetItem* curItem = m_presetList->item(i);
+        if (curItem->checkState() == Qt::Checked) {
+            anyShaderChecked = true;
+            const auto& feShader = m_presets[i - 1];
+            if (combined.getPasses().empty()) {
+                combined = feShader.preset;
+            } else {
+                combined.appendPassesFrom(feShader.preset);
+            }
+            if (!pathsStr.empty()) pathsStr += "+";
+            pathsStr += feShader.path;
+        }
+    }
+
+    m_presetList->blockSignals(true);
+    m_presetList->item(0)->setCheckState(anyShaderChecked ? Qt::Unchecked : Qt::Checked);
+
+    m_presetList->setCurrentItem(item); // Keep checked item highlighted in blue
+    onPresetSelected(item);
+    m_presetList->blockSignals(false);
+
+    m_shaderManager->RequestPresetLoad(anyShaderChecked ? combined : SlangPreset());
+
+    if (m_mainWindow) {
+        m_mainWindow->getWindowConfig().SetString("ShaderPresetPath", pathsStr);
+        Config::Save();
+    }
+}
+
+void ShaderConfigDialog::updateDetails(const FrontendShader& feShader) {
+    m_titleLabel->setText("<b>" + QString::fromStdString(feShader.name) + "</b>");
+
+    if (!feShader.author.empty()) m_authorLabel->setText("Author: " + QString::fromStdString(feShader.author));
+    else m_authorLabel->setText("Author: Unknown");
+
+    if (!feShader.description.empty()) m_descLabel->setText(QString::fromStdString(feShader.description));
+    else m_descLabel->setText("No description available.");
+
+    clearLayout(m_paramsLayout);
+
+    bool hasParams = false;
+
+    for (const auto& param : feShader.preset.getPragmaParameters()) {
+        hasParams = true;
+        QGroupBox* group = new QGroupBox(QString::fromStdString(param.description), m_paramsWidget);
+        QFormLayout* form = new QFormLayout(group);
+
+        float valToUse = param.defaultValue;
+        if (m_savedParameters.count(feShader.path) && m_savedParameters[feShader.path].count(param.name)) {
+            valToUse = m_savedParameters[feShader.path][param.name];
+        }
+
+        QLabel* valLabel = new QLabel(QString::number(valToUse, 'f', 2), group);
+        QSlider* slider = new QSlider(Qt::Horizontal, group);
+        slider->installEventFilter(this);
+
+        slider->setRange(0, 1000);
+        int startVal = (int)((valToUse - param.minValue) / (param.maxValue - param.minValue) * 1000.0f);
+
+        slider->setValue(qBound(0, startVal, 1000));
+
+        connect(slider, &QSlider::valueChanged, [this, param, valLabel, presetPath = feShader.path](int val) {
+            float floatVal = param.minValue + (float)val / 1000.0f * (param.maxValue - param.minValue);
+            valLabel->setText(QString::number(floatVal, 'f', 2));
+            onParameterChanged(param.name, floatVal);
+
+            m_savedParameters[presetPath][param.name] = floatVal;
+        });
+
+        form->addRow("Value:", valLabel);
+        form->addRow(slider);
+        m_paramsLayout->addWidget(group);
+
+        if (valToUse != param.defaultValue) {
+            onParameterChanged(param.name, valToUse);
+        }
+    }
+
+    for (const auto& [name, defaultValue] : feShader.preset.getParameters()) {
+        hasParams = true;
+        QGroupBox* group = new QGroupBox(QString::fromStdString(name), m_paramsWidget);
+        QFormLayout* form = new QFormLayout(group);
+
+        float valToUse = defaultValue;
+        if (m_savedParameters.count(feShader.path) && m_savedParameters[feShader.path].count(name)) {
+            valToUse = m_savedParameters[feShader.path][name];
+        }
+
+        QLabel* valLabel = new QLabel(QString::number(valToUse, 'f', 2), group);
+        form->addRow("Value:", valLabel);
+        m_paramsLayout->addWidget(group);
+
+        if (valToUse != defaultValue) {
+            onParameterChanged(name, valToUse);
+        }
+    }
+
+    m_resetButton->setVisible(hasParams);
+
+    connect(this, &QDialog::finished, [this, mainWin = m_mainWindow](int result){
+        if (mainWin) {
+            std::string str = "";
+            for (const auto& [pPath, pMap] : m_savedParameters) {
+                if (pMap.empty()) continue;
+                str += pPath + "|";
+                for (const auto& [n, v] : pMap) {
+                    str += n + "=" + std::to_string(v) + ";";
+                }
+                str += "#";
+            }
+            mainWin->getWindowConfig().SetString("ShaderParams", str);
+            Config::Save();
+        }
+    });
+}
+
+void ShaderConfigDialog::onParameterChanged(const std::string& name, float value) {
+    m_shaderManager->SetParameter(name, value);
+}
+
+void ShaderConfigDialog::onResetParameters() {
+    std::string currentPath = "";
+    int currentIndex = m_presetList->currentRow();
+    if (currentIndex > 0) {
+        currentPath = m_presets[currentIndex - 1].path;
+    }
+
+    if (currentPath.empty()) return;
+
+    m_savedParameters.erase(currentPath); // Clear saved values and reload defaults
+
+    const auto& feShader = m_presets[currentIndex - 1];
+
+    for (const auto& param : feShader.preset.getPragmaParameters()) {
+        onParameterChanged(param.name, param.defaultValue);
+    }
+    for (const auto& [name, defaultValue] : feShader.preset.getParameters()) {
+        onParameterChanged(name, defaultValue);
+    }
+
+    updateDetails(feShader);
+}
+
+void ShaderConfigDialog::clearLayout(QLayout* layout) {
+    if (!layout) return;
+    // Recursively delete all widgets and sub-layouts
+    while (QLayoutItem* item = layout->takeAt(0)) {
+        if (QWidget* widget = item->widget()) {
+            widget->deleteLater();
+        }
+        if (QLayout* childLayout = item->layout()) {
+            clearLayout(childLayout);
+        }
+        delete item;
+    }
+}

--- a/src/frontend/qt_sdl/ShaderConfigDialog.h
+++ b/src/frontend/qt_sdl/ShaderConfigDialog.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QDialog>
+#include <QListWidget>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include <memory>
+#include "FrontendShader.h"
+#include "ShaderManager.h"
+
+class MainWindow;
+
+class ShaderConfigDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ShaderConfigDialog(ShaderManager* manager, const std::vector<FrontendShader>& presets, MainWindow* mainWindow);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+
+private slots:
+    void onPresetSelected(QListWidgetItem* item);
+    // Called when a checkbox is toggled — rebuilds the combined preset and reloads
+    void onPresetChanged(QListWidgetItem* item);
+    void onParameterChanged(const std::string& name, float value);
+    void onResetParameters();
+
+private:
+    void setupUI();
+    void loadPresets();
+    void updateDetails(const FrontendShader& feShader);
+    void clearLayout(QLayout* layout);
+
+    ShaderManager* m_shaderManager;
+    std::vector<FrontendShader> m_presets;
+    MainWindow* m_mainWindow;
+
+    QListWidget* m_presetList;
+    QLabel* m_titleLabel;
+    QLabel* m_authorLabel;
+    QLabel* m_descLabel;
+    QWidget* m_paramsWidget;
+    QVBoxLayout* m_paramsLayout;
+    QPushButton* m_resetButton;
+    
+    // User-modified parameter values per preset path
+    std::map<std::string, std::map<std::string, float>> m_savedParameters;
+};

--- a/src/frontend/qt_sdl/ShaderManager.cpp
+++ b/src/frontend/qt_sdl/ShaderManager.cpp
@@ -1,0 +1,913 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include "ShaderManager.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <QImage>
+
+#include <glslang/Public/ShaderLang.h>
+#include <glslang/SPIRV/GlslangToSpv.h>
+#include <spirv_cross/spirv_glsl.hpp>
+
+class SlangIncluder : public glslang::TShader::Includer {
+public:
+    SlangIncluder(const std::string& baseDir) : m_baseDir(baseDir) {}
+
+    IncludeResult* includeSystem(const char* headerName, const char* includerName, size_t inclusionDepth) override {
+        return nullptr;
+    }
+
+    IncludeResult* includeLocal(const char* headerName, const char* includerName, size_t inclusionDepth) override {
+        std::string fullPath = m_baseDir + "/" + headerName;
+        std::ifstream file(fullPath);
+        if (!file.is_open()) return nullptr;
+
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        std::string content = buffer.str();
+
+        char* allocatedContent = new char[content.length() + 1];
+        std::strcpy(allocatedContent, content.c_str());
+
+        return new IncludeResult(fullPath, allocatedContent, content.length(), allocatedContent);
+    }
+
+    void releaseInclude(IncludeResult* result) override {
+        if (result && result->userData) {
+            delete[] static_cast<char*>(result->userData);
+        }
+        delete result;
+    }
+
+private:
+    std::string m_baseDir;
+};
+
+void CheckGLError(const char* label) {
+    GLenum err;
+    while ((err = glGetError()) != GL_NO_ERROR) {
+        std::cerr << "OpenGL Error at " << label << ": " << err << std::endl;
+    }
+}
+
+void InitResources(TBuiltInResource& Resources) {
+    Resources.maxLights = 32;
+    Resources.maxClipPlanes = 6;
+    Resources.maxTextureUnits = 32;
+    Resources.maxTextureCoords = 32;
+    Resources.maxVertexAttribs = 64;
+    Resources.maxVertexUniformComponents = 4096;
+    Resources.maxVaryingFloats = 64;
+    Resources.maxVertexTextureImageUnits = 32;
+    Resources.maxCombinedTextureImageUnits = 80;
+    Resources.maxTextureImageUnits = 32;
+    Resources.maxFragmentUniformComponents = 4096;
+    Resources.maxDrawBuffers = 32;
+    Resources.maxVertexUniformVectors = 128;
+    Resources.maxVaryingVectors = 8;
+    Resources.maxFragmentUniformVectors = 16;
+    Resources.maxVertexOutputVectors = 16;
+    Resources.maxFragmentInputVectors = 15;
+    Resources.minProgramTexelOffset = -8;
+    Resources.maxProgramTexelOffset = 7;
+    Resources.maxClipDistances = 8;
+    Resources.maxComputeWorkGroupCountX = 65535;
+    Resources.maxComputeWorkGroupCountY = 65535;
+    Resources.maxComputeWorkGroupCountZ = 65535;
+    Resources.maxComputeWorkGroupSizeX = 1024;
+    Resources.maxComputeWorkGroupSizeY = 1024;
+    Resources.maxComputeWorkGroupSizeZ = 64;
+    Resources.maxComputeUniformComponents = 1024;
+    Resources.maxComputeTextureImageUnits = 16;
+    Resources.maxComputeImageUniforms = 8;
+    Resources.maxComputeAtomicCounters = 8;
+    Resources.maxComputeAtomicCounterBuffers = 1;
+    Resources.maxVaryingComponents = 60;
+    Resources.maxVertexOutputComponents = 64;
+    Resources.maxGeometryInputComponents = 64;
+    Resources.maxGeometryOutputComponents = 128;
+    Resources.maxFragmentInputComponents = 128;
+    Resources.maxImageUnits = 8;
+    Resources.maxCombinedImageUnitsAndFragmentOutputs = 8;
+    Resources.maxCombinedShaderOutputResources = 8;
+    Resources.maxImageSamples = 0;
+    Resources.maxVertexImageUniforms = 0;
+    Resources.maxTessControlImageUniforms = 0;
+    Resources.maxTessEvaluationImageUniforms = 0;
+    Resources.maxGeometryImageUniforms = 0;
+    Resources.maxFragmentImageUniforms = 8;
+    Resources.maxCombinedImageUniforms = 8;
+    Resources.maxGeometryTextureImageUnits = 16;
+    Resources.maxGeometryOutputVertices = 256;
+    Resources.maxGeometryTotalOutputComponents = 1024;
+    Resources.maxGeometryUniformComponents = 1024;
+    Resources.maxGeometryVaryingComponents = 64;
+    Resources.maxTessControlInputComponents = 128;
+    Resources.maxTessControlOutputComponents = 128;
+    Resources.maxTessControlTextureImageUnits = 16;
+    Resources.maxTessControlUniformComponents = 1024;
+    Resources.maxTessControlTotalOutputComponents = 4096;
+    Resources.maxTessEvaluationInputComponents = 128;
+    Resources.maxTessEvaluationOutputComponents = 128;
+    Resources.maxTessEvaluationTextureImageUnits = 16;
+    Resources.maxTessEvaluationUniformComponents = 1024;
+    Resources.maxTessPatchComponents = 120;
+    Resources.maxPatchVertices = 32;
+    Resources.maxTessGenLevel = 64;
+    Resources.maxViewports = 16;
+    Resources.maxVertexAtomicCounters = 0;
+    Resources.maxTessControlAtomicCounters = 0;
+    Resources.maxTessEvaluationAtomicCounters = 0;
+    Resources.maxGeometryAtomicCounters = 0;
+    Resources.maxFragmentAtomicCounters = 8;
+    Resources.maxCombinedAtomicCounters = 8;
+    Resources.maxAtomicCounterBindings = 1;
+    Resources.maxVertexAtomicCounterBuffers = 0;
+    Resources.maxTessControlAtomicCounterBuffers = 0;
+    Resources.maxTessEvaluationAtomicCounterBuffers = 0;
+    Resources.maxGeometryAtomicCounterBuffers = 0;
+    Resources.maxFragmentAtomicCounterBuffers = 1;
+    Resources.maxCombinedAtomicCounterBuffers = 1;
+    Resources.maxAtomicCounterBufferSize = 16384;
+    Resources.maxTransformFeedbackBuffers = 4;
+    Resources.maxTransformFeedbackInterleavedComponents = 64;
+    Resources.maxCullDistances = 8;
+    Resources.maxCombinedClipAndCullDistances = 8;
+    Resources.maxSamples = 4;
+    Resources.maxMeshOutputVerticesNV = 256;
+    Resources.maxMeshOutputPrimitivesNV = 512;
+    Resources.maxMeshWorkGroupSizeX_NV = 32;
+    Resources.maxMeshWorkGroupSizeY_NV = 1;
+    Resources.maxMeshWorkGroupSizeZ_NV = 1;
+    Resources.maxTaskWorkGroupSizeX_NV = 32;
+    Resources.maxTaskWorkGroupSizeY_NV = 1;
+    Resources.maxTaskWorkGroupSizeZ_NV = 1;
+    Resources.maxMeshViewCountNV = 4;
+
+    Resources.limits.nonInductiveForLoops = 1;
+    Resources.limits.whileLoops = 1;
+    Resources.limits.doWhileLoops = 1;
+    Resources.limits.generalUniformIndexing = 1;
+    Resources.limits.generalAttributeMatrixVectorIndexing = 1;
+    Resources.limits.generalVaryingIndexing = 1;
+    Resources.limits.generalSamplerIndexing = 1;
+    Resources.limits.generalVariableIndexing = 1;
+    Resources.limits.generalConstantMatrixVectorIndexing = 1;
+}
+
+ShaderManager::ShaderManager() {
+    static bool glslangInitialized = false;
+    if (!glslangInitialized) {
+        glslang::InitializeProcess();
+        glslangInitialized = true;
+    }
+    InitQuad();
+    glGenBuffers(1, &m_globalUBO);
+    glGenBuffers(1, &m_pushConstantsUBO);
+}
+
+ShaderManager::~ShaderManager() {
+    CleanupFBOs();
+
+    for (GLuint prog : m_shaderPrograms) {
+        if (prog) glDeleteProgram(prog);
+    }
+
+    if (m_globalUBO) glDeleteBuffers(1, &m_globalUBO);
+    if (m_pushConstantsUBO) glDeleteBuffers(1, &m_pushConstantsUBO);
+    if (m_quadVAO) glDeleteVertexArrays(1, &m_quadVAO);
+    if (m_quadVBO) glDeleteBuffers(1, &m_quadVBO);
+}
+
+void ShaderManager::InitQuad() {
+    // Full-screen quad used to render shader pass outputs
+    float vertices[] = {
+        // pos        // tex
+        -1.0f, -1.0f, 0.0f, 0.0f,
+         1.0f, -1.0f, 1.0f, 0.0f,
+        -1.0f,  1.0f, 0.0f, 1.0f,
+         1.0f,  1.0f, 1.0f, 1.0f
+    };
+
+    glGenVertexArrays(1, &m_quadVAO);
+    glGenBuffers(1, &m_quadVBO);
+
+    glBindVertexArray(m_quadVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, m_quadVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), &vertices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+
+    glBindVertexArray(0);
+}
+
+void ShaderManager::CleanupFBOs() {
+    if (m_fboA.fbo) {
+        glDeleteFramebuffers(1, &m_fboA.fbo);
+        glDeleteTextures(1, &m_fboA.texture);
+    }
+    if (m_fboB.fbo) {
+        glDeleteFramebuffers(1, &m_fboB.fbo);
+        glDeleteTextures(1, &m_fboB.texture);
+    }
+    for (auto& fbo : m_passFBOs) {
+        if (fbo.fbo) {
+            glDeleteFramebuffers(1, &fbo.fbo);
+            glDeleteTextures(1, &fbo.texture);
+        }
+    }
+    m_passFBOs.clear();
+
+    for (auto& pair : m_lutTextures) {
+        glDeleteTextures(1, &pair.second);
+    }
+    m_lutTextures.clear();
+
+    if (m_extractFBO) glDeleteFramebuffers(1, &m_extractFBO);
+    if (m_outputArrayFBO) glDeleteFramebuffers(1, &m_outputArrayFBO);
+    if (m_outputArrayTex) glDeleteTextures(1, &m_outputArrayTex);
+
+    m_fboA = ShaderFBO{};
+    m_fboB = ShaderFBO{}; // Reset FBO trackers after deleting
+    m_extractFBO = 0;
+    m_outputArrayFBO = 0;
+    m_outputArrayTex = 0;
+}
+void ShaderManager::ResizeOutputArray(int width, int height) {
+    if (m_outputArrayWidth == width && m_outputArrayHeight == height && m_outputArrayTex != 0) {
+        return; // Already the correct size
+    }
+
+    if (m_outputArrayTex == 0) {
+        glGenTextures(1, &m_outputArrayTex);
+        glGenFramebuffers(1, &m_outputArrayFBO);
+    }
+
+    m_outputArrayWidth = width;
+    m_outputArrayHeight = height;
+
+    glBindTexture(GL_TEXTURE_2D_ARRAY, m_outputArrayTex);
+    glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, width, height, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+}
+
+void ShaderManager::ResizeFBO(ShaderFBO& fbo, int width, int height, bool linearFilter, bool srgb, bool floatFbo) {
+    if (fbo.width == width && fbo.height == height && fbo.fbo != 0) {
+        return; // Already the correct size
+    }
+
+    if (fbo.fbo == 0) {
+        glGenFramebuffers(1, &fbo.fbo);
+        glGenTextures(1, &fbo.texture);
+    }
+
+    fbo.width = width;
+    fbo.height = height;
+
+    glBindTexture(GL_TEXTURE_2D, fbo.texture);
+    GLint internalFormat = GL_RGBA8;
+    GLenum type = GL_UNSIGNED_BYTE;
+
+    if (floatFbo) {
+        internalFormat = GL_RGBA32F;
+        type = GL_FLOAT;
+    } else if (srgb) {
+        internalFormat = GL_SRGB8_ALPHA8;
+    }
+
+    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, GL_RGBA, type, nullptr);
+
+    GLint filter = linearFilter ? GL_LINEAR : GL_NEAREST;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo.fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, fbo.texture, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+bool ShaderManager::CompileShaderPass(const std::string& slangPath, GLuint& outProgram) {
+    std::ifstream file(slangPath);
+    if (!file.is_open()) {
+        std::cerr << "Failed to open shader: " << slangPath << std::endl;
+        return false;
+    }
+
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string source = buffer.str();
+
+    size_t lastSlash = slangPath.find_last_of("/\\");
+    std::string baseDir = (lastSlash == std::string::npos) ? "." : slangPath.substr(0, lastSlash);
+
+    auto expandIncludes = [](const std::string& src, const std::string& dir, auto& expandRef) -> std::string {
+        std::stringstream in(src);
+        std::stringstream out;
+        std::string line;
+        while (std::getline(in, line)) {
+            if (line.find("#include") != std::string::npos) {
+                size_t firstQuote = line.find('"');
+                size_t lastQuote = line.find('"', firstQuote + 1);
+                if (firstQuote != std::string::npos && lastQuote != std::string::npos) {
+                    std::string incFile = line.substr(firstQuote + 1, lastQuote - firstQuote - 1);
+                    std::string incPath = dir + "/" + incFile;
+                    std::ifstream inc(incPath);
+                    if (inc.is_open()) {
+                        std::stringstream incBuf;
+                        incBuf << inc.rdbuf();
+                        size_t incSlash = incPath.find_last_of("/\\");
+                        std::string incDir = (incSlash == std::string::npos) ? "." : incPath.substr(0, incSlash);
+                        out << expandRef(incBuf.str(), incDir, expandRef) << "\n";
+                        continue;
+                    }
+                }
+            }
+            out << line << "\n";
+        }
+        return out.str();
+    };
+
+    source = expandIncludes(source, baseDir, expandIncludes);
+    
+    size_t versionPos = source.find("#version");
+    if (versionPos != std::string::npos) {
+        size_t endOfLine = source.find('\n', versionPos);
+        if (endOfLine != std::string::npos) {
+            source.insert(endOfLine + 1, "#extension GL_GOOGLE_include_directive : enable\n");
+        } else {
+            source.append("\n#extension GL_GOOGLE_include_directive : enable\n");
+        }
+    } else {
+        source.insert(0, "#extension GL_GOOGLE_include_directive : enable\n");
+    }
+
+    const std::string P_VERT = "#pragma stage vertex";
+    const std::string P_FRAG = "#pragma stage fragment";
+
+    size_t vert_pragma_pos = source.find(P_VERT);
+    size_t frag_pragma_pos = source.find(P_FRAG);
+
+    if (vert_pragma_pos == std::string::npos) {
+        std::cerr << "Shader " << slangPath << " is missing #pragma stage vertex" << std::endl;
+        return false;
+    }
+    if (frag_pragma_pos == std::string::npos) {
+        std::cerr << "Shader " << slangPath << " is missing #pragma stage fragment" << std::endl;
+        return false;
+    }
+
+    std::string common_source;
+    std::string vert_specific;
+    std::string frag_specific;
+
+    if (vert_pragma_pos < frag_pragma_pos) {
+        common_source = source.substr(0, vert_pragma_pos);
+        vert_specific = source.substr(vert_pragma_pos, frag_pragma_pos - vert_pragma_pos);
+        frag_specific = source.substr(frag_pragma_pos);
+    } else {
+        common_source = source.substr(0, frag_pragma_pos);
+        frag_specific = source.substr(frag_pragma_pos, vert_pragma_pos - frag_pragma_pos);
+        vert_specific = source.substr(vert_pragma_pos);
+    }
+
+    std::string final_vert_source = common_source + vert_specific;
+    std::string final_frag_source = common_source + frag_specific;
+
+    auto compileToSPIRV = [&](EShLanguage stage, const std::string& code, std::vector<unsigned int>& spirv) -> bool {
+        glslang::TShader shader(stage);
+
+        const char* codeStrs[1] = { code.c_str() };
+        shader.setStrings(codeStrs, 1);
+
+        shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 450);
+        shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
+        shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_0);
+
+        TBuiltInResource resources;
+        InitResources(resources);
+
+        size_t lastSlash = slangPath.find_last_of("/\\");
+        std::string baseDir = (lastSlash == std::string::npos) ? "." : slangPath.substr(0, lastSlash);
+        SlangIncluder includer(baseDir);
+
+        if (!shader.parse(&resources, 450, false, (EShMessages)(EShMsgDefault | EShMsgVulkanRules | EShMsgSpvRules), includer)) {
+            std::cerr << "Glslang parsing failed for " << slangPath << " (" << (stage == EShLangVertex ? "Vertex" : "Fragment") << "):\n" << shader.getInfoLog() << "\n" << shader.getInfoDebugLog() << std::endl;
+            return false;
+        }
+
+        glslang::TProgram program;
+        program.addShader(&shader);
+        if (!program.link(EShMsgDefault)) {
+            std::cerr << "Glslang linking failed for " << slangPath << ":\n" << program.getInfoLog() << "\n" << program.getInfoDebugLog() << std::endl;
+            return false;
+        }
+
+        glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
+        return true;
+    };
+
+    std::vector<unsigned int> vertSpirv;
+    std::vector<unsigned int> fragSpirv;
+
+    if (!compileToSPIRV(EShLangVertex, final_vert_source, vertSpirv)) return false;
+    if (!compileToSPIRV(EShLangFragment, final_frag_source, fragSpirv)) return false;
+
+    auto spirvToGLSL = [&](const std::vector<unsigned int>& spirv, const std::string& stageName) -> std::string {
+        spirv_cross::CompilerGLSL compiler(spirv);
+
+        spirv_cross::CompilerGLSL::Options options;
+        options.version = 430;
+        options.es = false;
+        options.emit_push_constant_as_uniform_buffer = true;
+        compiler.set_common_options(options);
+        return compiler.compile();
+    };
+
+    std::string vertGLSL, fragGLSL;
+    try {
+        vertGLSL = spirvToGLSL(vertSpirv, "vertex");
+        fragGLSL = spirvToGLSL(fragSpirv, "fragment");
+    } catch (const spirv_cross::CompilerError& e) {
+        std::cerr << "SPIRV-Cross failed: " << e.what() << std::endl;
+        return false;
+    }
+
+    auto compileGL = [&](GLenum type, const std::string& src) -> GLuint {
+        GLuint shader = glCreateShader(type);
+        const char* c_str = src.c_str();
+        glShaderSource(shader, 1, &c_str, nullptr);
+        glCompileShader(shader);
+
+        GLint success;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+        if (!success) {
+            GLint logSize = 0;
+            glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logSize);
+            std::string infoLogStr;
+            if (logSize > 0) {
+                std::vector<char> infoLog(logSize);
+                glGetShaderInfoLog(shader, logSize, nullptr, infoLog.data());
+                infoLogStr.assign(infoLog.begin(), infoLog.end() - 1); // remove null terminator
+            }
+            std::cerr << "OpenGL Compile Error in " << (type == GL_VERTEX_SHADER ? "Vertex" : "Fragment") << " shader:\n" << infoLogStr << std::endl;
+            std::cerr << "--- Shader Source ---\n" << src << "\n---------------------\n";
+            return 0;
+        }
+        return shader;
+    };
+
+    GLuint vertShader = compileGL(GL_VERTEX_SHADER, vertGLSL);
+    GLuint fragShader = compileGL(GL_FRAGMENT_SHADER, fragGLSL);
+
+    if (!vertShader || !fragShader) return false;
+
+    outProgram = glCreateProgram();
+    glAttachShader(outProgram, vertShader);
+    glAttachShader(outProgram, fragShader);
+    glLinkProgram(outProgram);
+
+    GLint linkSuccess;
+    glGetProgramiv(outProgram, GL_LINK_STATUS, &linkSuccess);
+    if (!linkSuccess) {
+        char infoLog[1024];
+        glGetProgramInfoLog(outProgram, 1024, nullptr, infoLog);
+        std::cerr << "OpenGL Link Error: " << infoLog << std::endl;
+        glDeleteProgram(outProgram);
+        outProgram = 0;
+        return false;
+    }
+
+    glDeleteShader(vertShader);
+    glDeleteShader(fragShader);
+
+    ProgramLayout progLayout;
+
+    GLint numActiveUniforms;
+    glGetProgramiv(outProgram, GL_ACTIVE_UNIFORMS, &numActiveUniforms);
+    for (int i = 0; i < numActiveUniforms; ++i) {
+        char name[256];
+        GLint size;
+        GLenum type;
+        glGetActiveUniform(outProgram, i, 256, nullptr, &size, &type, name);
+        
+        std::string sName(name);
+        GLint loc = glGetUniformLocation(outProgram, name);
+        
+        progLayout.uniformLocations[sName] = loc;
+        size_t dotPos = sName.find('.');
+        if (dotPos != std::string::npos) {
+            std::string noPrefix = sName.substr(dotPos + 1);
+            size_t bracketPos = noPrefix.find('[');
+            if (bracketPos != std::string::npos) noPrefix = noPrefix.substr(0, bracketPos);
+            progLayout.uniformLocations[noPrefix] = loc;
+        } else {
+            size_t bracketPos = sName.find('[');
+            if (bracketPos != std::string::npos) sName = sName.substr(0, bracketPos);
+            progLayout.uniformLocations[sName] = loc;
+        }
+    }
+
+    auto extractLayout = [&](const char* name1, const char* name2, UniformLayout& layout, GLuint bindingPoint) {
+        layout.blockIndex = glGetUniformBlockIndex(outProgram, name1);
+        if (layout.blockIndex == GL_INVALID_INDEX && name2) {
+            layout.blockIndex = glGetUniformBlockIndex(outProgram, name2);
+        }
+
+        if (layout.blockIndex != GL_INVALID_INDEX) {
+            glUniformBlockBinding(outProgram, layout.blockIndex, bindingPoint);
+            glGetActiveUniformBlockiv(outProgram, layout.blockIndex, GL_UNIFORM_BLOCK_DATA_SIZE, &layout.blockSize);
+
+            GLint numUniforms;
+            glGetActiveUniformBlockiv(outProgram, layout.blockIndex, GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS, &numUniforms);
+
+            if (numUniforms > 0) {
+                std::vector<GLint> indices(numUniforms);
+                glGetActiveUniformBlockiv(outProgram, layout.blockIndex, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, indices.data());
+
+                std::vector<GLint> offsets(numUniforms);
+                glGetActiveUniformsiv(outProgram, numUniforms, (GLuint*)indices.data(), GL_UNIFORM_OFFSET, offsets.data());
+
+                for (int i = 0; i < numUniforms; ++i) {
+                    char name[256];
+                    glGetActiveUniformName(outProgram, indices[i], 256, nullptr, name);
+                    std::string sName(name);
+                    
+                    size_t dotPos = sName.find('.');
+                    if (dotPos != std::string::npos) sName = sName.substr(dotPos + 1);
+                    
+                    size_t bracketPos = sName.find('[');
+                    if (bracketPos != std::string::npos) sName = sName.substr(0, bracketPos);
+                    
+                    layout.offsets[sName] = (size_t)offsets[i];
+                }
+            }
+        }
+    };
+
+    extractLayout("UBO", "global", progLayout.globalUBO, 0);
+    extractLayout("Push", "params", progLayout.pushUBO, 1);
+
+    m_programLayouts.push_back(progLayout);
+
+    return true;
+}
+
+void ShaderManager::RequestPresetLoad(const SlangPreset& preset) {
+    std::lock_guard<std::mutex> lock(m_pendingMutex);
+    m_pendingPreset = preset;
+    m_presetPending = true;
+}
+
+bool ShaderManager::LoadPreset(const SlangPreset& preset) {
+    if (preset.getPasses().empty()) {
+        for (GLuint prog : m_shaderPrograms) {
+            if (prog) glDeleteProgram(prog);
+        }
+        m_shaderPrograms.clear();
+        m_programLayouts.clear();
+        m_preset.clear();
+        m_parameters.clear();
+        for (auto& pair : m_lutTextures) {
+            glDeleteTextures(1, &pair.second);
+        }
+        m_lutTextures.clear();
+        return true;
+    }
+
+    m_preset = preset;
+
+    for (auto& fbo : m_passFBOs) {
+        if (fbo.fbo) {
+            glDeleteFramebuffers(1, &fbo.fbo);
+            glDeleteTextures(1, &fbo.texture);
+        }
+    }
+    m_passFBOs.clear();
+
+    for (GLuint prog : m_shaderPrograms) {
+        if (prog) glDeleteProgram(prog);
+    }
+    m_shaderPrograms.clear();
+    m_programLayouts.clear();
+    
+    for (auto& pair : m_lutTextures) {
+        glDeleteTextures(1, &pair.second);
+    }
+    m_lutTextures.clear();
+
+    for (const auto& lut : m_preset.getLUTs()) {
+        QImage img(QString::fromStdString(lut.path));
+        if (img.isNull()) {
+            std::cerr << "Failed to load LUT: " << lut.path << std::endl;
+            continue;
+        }
+        img = img.convertToFormat(QImage::Format_RGBA8888);
+
+        GLuint tex;
+        glGenTextures(1, &tex);
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, img.width(), img.height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, img.bits());
+        
+        GLint filter = lut.linear ? GL_LINEAR : GL_NEAREST;
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        
+        m_lutTextures[lut.id] = tex;
+    }
+
+    std::map<std::string, float> oldParams = m_parameters;
+    m_parameters = m_preset.getParameters();
+    for (const auto& pragma_param : m_preset.getPragmaParameters()) {
+        if (m_parameters.find(pragma_param.name) == m_parameters.end()) {
+             m_parameters[pragma_param.name] = pragma_param.defaultValue;
+        }
+    }
+    for (const auto& [name, val] : oldParams) {
+        if (m_parameters.count(name)) {
+            m_parameters[name] = val;
+        }
+    }
+
+    const auto& passes = m_preset.getPasses();
+    for (const auto& pass : passes) {
+        GLuint program = 0;
+        if (!CompileShaderPass(pass.shaderPath, program)) {
+            std::cerr << "Failed to compile pass: " << pass.shaderPath << std::endl;
+            for (GLuint prog : m_shaderPrograms) {
+                if (prog) glDeleteProgram(prog);
+            }
+            m_shaderPrograms.clear();
+            m_programLayouts.clear();
+            return false;
+        }
+        m_shaderPrograms.push_back(program);
+    }
+
+    return true;
+}
+
+void ShaderManager::SetParameter(const std::string& name, float value) {
+    std::lock_guard<std::mutex> lock(m_pendingMutex);
+    m_parameters[name] = value;
+}
+
+GLuint ShaderManager::Process(GLuint inputTexArray, int inputWidth, int inputHeight, int windowWidth, int windowHeight, int& outWidth, int& outHeight) {
+    {
+        std::lock_guard<std::mutex> lock(m_pendingMutex);
+        if (m_presetPending) {
+            LoadPreset(m_pendingPreset);
+            m_presetPending = false;
+        }
+    }
+
+    const auto& passes = m_preset.getPasses();
+
+    if (passes.empty() || m_shaderPrograms.empty() || m_shaderPrograms[0] == 0) {
+        outWidth = inputWidth;
+        outHeight = inputHeight;
+        return inputTexArray;
+    }
+
+    int finalWidth = inputWidth;
+    int finalHeight = inputHeight;
+    for (const auto& pass : passes) {
+        if (pass.scaleTypeX == "source") finalWidth = static_cast<int>(finalWidth * pass.scaleX);
+        if (pass.scaleTypeY == "source") finalHeight = static_cast<int>(finalHeight * pass.scaleY);
+        if (pass.scaleTypeX == "viewport") finalWidth = static_cast<int>(windowWidth * pass.scaleX);
+        if (pass.scaleTypeY == "viewport") finalHeight = static_cast<int>(windowHeight * pass.scaleY);
+        if (pass.scaleTypeX == "absolute") finalWidth = static_cast<int>(pass.scaleX);
+        if (pass.scaleTypeY == "absolute") finalHeight = static_cast<int>(pass.scaleY);
+    }
+
+    outWidth = finalWidth;
+    outHeight = finalHeight;
+
+    ResizeOutputArray(outWidth, outHeight);
+
+    if (m_extractFBO == 0) {
+        glGenFramebuffers(1, &m_extractFBO);
+    }
+
+    glBindVertexArray(m_quadVAO);
+
+    m_frameCount++;
+
+    if (m_passFBOs.size() != passes.size()) {
+        for (auto& fbo : m_passFBOs) {
+            if (fbo.fbo) {
+                glDeleteFramebuffers(1, &fbo.fbo);
+                glDeleteTextures(1, &fbo.texture);
+            }
+        }
+        m_passFBOs.clear();
+        m_passFBOs.resize(passes.size());
+    }
+
+    for (int layer = 0; layer < 2; ++layer) {
+        ResizeFBO(m_fboA, inputWidth, inputHeight, false);
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, m_extractFBO);
+        glFramebufferTextureLayer(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, inputTexArray, 0, layer);
+
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fboA.fbo);
+        glBlitFramebuffer(0, 0, inputWidth, inputHeight,
+                          0, 0, inputWidth, inputHeight,
+                          GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+        GLuint currentInputTex = m_fboA.texture;
+        int currentWidth = inputWidth;
+        int currentHeight = inputHeight;
+
+        GLuint originalTex = currentInputTex;
+        int originalWidth = currentWidth;
+        int originalHeight = currentHeight;
+
+        for (size_t i = 0; i < passes.size(); ++i) {
+            const auto& pass = passes[i];
+            if (m_shaderPrograms[i] == 0) continue;
+
+            int targetWidth = currentWidth;
+            int targetHeight = currentHeight;
+
+            if (pass.scaleTypeX == "source") {
+                targetWidth = static_cast<int>(currentWidth * pass.scaleX);
+            } else if (pass.scaleTypeX == "viewport") {
+                targetWidth = static_cast<int>(windowWidth * pass.scaleX);
+            } else if (pass.scaleTypeX == "absolute") {
+                targetWidth = static_cast<int>(pass.scaleX);
+            }
+
+            if (pass.scaleTypeY == "source") {
+                targetHeight = static_cast<int>(currentHeight * pass.scaleY);
+            } else if (pass.scaleTypeY == "viewport") {
+                targetHeight = static_cast<int>(windowHeight * pass.scaleY);
+            } else if (pass.scaleTypeY == "absolute") {
+                targetHeight = static_cast<int>(pass.scaleY);
+            }
+
+            bool isLastPass = (i == passes.size() - 1);
+
+            if (isLastPass) {
+                glBindFramebuffer(GL_FRAMEBUFFER, m_outputArrayFBO);
+                glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_outputArrayTex, 0, layer);
+                glClear(GL_COLOR_BUFFER_BIT);
+            } else {
+                ResizeFBO(m_passFBOs[i], targetWidth, targetHeight, pass.filterLinear, pass.srgbFramebuffer, pass.floatFramebuffer);
+                glBindFramebuffer(GL_FRAMEBUFFER, m_passFBOs[i].fbo);
+                glClear(GL_COLOR_BUFFER_BIT);
+            }
+
+            if (pass.srgbFramebuffer) glEnable(GL_FRAMEBUFFER_SRGB);
+            else glDisable(GL_FRAMEBUFFER_SRGB);
+
+            glViewport(0, 0, targetWidth, targetHeight);
+            glUseProgram(m_shaderPrograms[i]);
+
+            const auto& progLayout = m_programLayouts[i];
+            
+            auto fillUBO = [&](const UniformLayout& layout, GLuint uboID, GLuint bindingPoint, bool isPush) {
+                std::vector<uint8_t> uboData;
+                if (layout.blockSize > 0) uboData.resize(layout.blockSize, 0);
+
+                auto setF = [&](const std::string& name, float val) {
+                    if (layout.blockSize > 0 && layout.offsets.count(name)) {
+                        *(float*)(uboData.data() + layout.offsets.at(name)) = val;
+                    } else if (isPush || name == "MVP") {
+                        if (progLayout.uniformLocations.count(name)) {
+                            glUniform1f(progLayout.uniformLocations.at(name), val);
+                        }
+                    }
+                };
+                auto setV4 = [&](const std::string& name, float x, float y, float z, float w) {
+                    if (layout.blockSize > 0 && layout.offsets.count(name)) {
+                        float* ptr = (float*)(uboData.data() + layout.offsets.at(name));
+                        ptr[0] = x; ptr[1] = y; ptr[2] = z; ptr[3] = w;
+                    } else if (isPush || name.find("Size") != std::string::npos) {
+                        if (progLayout.uniformLocations.count(name)) {
+                            glUniform4f(progLayout.uniformLocations.at(name), x, y, z, w);
+                        }
+                    }
+                };
+                auto setM4 = [&](const std::string& name, const float* m) {
+                    if (layout.blockSize > 0 && layout.offsets.count(name)) {
+                        float* ptr = (float*)(uboData.data() + layout.offsets.at(name));
+                        for (int j = 0; j < 16; ++j) ptr[j] = m[j];
+                    } else if (isPush || name == "MVP") {
+                        if (progLayout.uniformLocations.count(name)) {
+                            glUniformMatrix4fv(progLayout.uniformLocations.at(name), 1, GL_FALSE, m);
+                        }
+                    }
+                };
+
+                const float mvp[16] = { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f };
+                setM4("MVP", mvp);
+                setV4("SourceSize", (float)currentWidth, (float)currentHeight, 1.0f / (float)currentWidth, 1.0f / (float)currentHeight);
+                setV4("OriginalSize", (float)originalWidth, (float)originalHeight, 1.0f / (float)originalWidth, 1.0f / (float)originalHeight);
+                setV4("OutputSize", (float)targetWidth, (float)targetHeight, 1.0f / (float)targetWidth, 1.0f / (float)targetHeight);
+                setF("FrameCount", (float)m_frameCount);
+                setF("FrameDirection", 1.0f);
+                setF("Rotation", 0.0f);
+
+                for (size_t prevPass = 0; prevPass < i; ++prevPass) {
+                    if (!passes[prevPass].alias.empty()) {
+                        std::string aliasSizeName = passes[prevPass].alias + "Size";
+                        setV4(aliasSizeName, (float)m_passFBOs[prevPass].width, (float)m_passFBOs[prevPass].height, 
+                              1.0f / (float)m_passFBOs[prevPass].width, 1.0f / (float)m_passFBOs[prevPass].height);
+                    }
+                    std::string passSizeName = "PassOutput" + std::to_string(prevPass) + "Size";
+                    setV4(passSizeName, (float)m_passFBOs[prevPass].width, (float)m_passFBOs[prevPass].height, 
+                          1.0f / (float)m_passFBOs[prevPass].width, 1.0f / (float)m_passFBOs[prevPass].height);
+                }
+
+                for (const auto& [name, value] : m_parameters) {
+                    setF(name, value);
+                }
+
+                if (layout.blockSize > 0) {
+                    glBindBuffer(GL_UNIFORM_BUFFER, uboID);
+                    glBufferData(GL_UNIFORM_BUFFER, layout.blockSize, uboData.data(), GL_DYNAMIC_DRAW);
+                    glBindBufferBase(GL_UNIFORM_BUFFER, bindingPoint, uboID);
+                }
+            };
+
+            fillUBO(progLayout.globalUBO, m_globalUBO, 0, false);
+            fillUBO(progLayout.pushUBO, m_pushConstantsUBO, 1, true);
+
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, currentInputTex);
+            if (progLayout.uniformLocations.count("Source")) glUniform1i(progLayout.uniformLocations.at("Source"), 0);
+
+            glActiveTexture(GL_TEXTURE1);
+            glBindTexture(GL_TEXTURE_2D, originalTex);
+            if (progLayout.uniformLocations.count("Original")) glUniform1i(progLayout.uniformLocations.at("Original"), 1);
+
+            int texUnit = 2;
+            for (size_t prevPass = 0; prevPass < i; ++prevPass) {
+                glActiveTexture(GL_TEXTURE0 + texUnit);
+                glBindTexture(GL_TEXTURE_2D, m_passFBOs[prevPass].texture);
+                
+                std::string passName = "PassOutput" + std::to_string(prevPass);
+                if (progLayout.uniformLocations.count(passName)) glUniform1i(progLayout.uniformLocations.at(passName), texUnit);
+
+                if (!passes[prevPass].alias.empty()) {
+                    if (progLayout.uniformLocations.count(passes[prevPass].alias)) glUniform1i(progLayout.uniformLocations.at(passes[prevPass].alias), texUnit);
+                }
+                texUnit++;
+            }
+
+            for (const auto& pair : m_lutTextures) {
+                glActiveTexture(GL_TEXTURE0 + texUnit);
+                glBindTexture(GL_TEXTURE_2D, pair.second);
+                if (progLayout.uniformLocations.count(pair.first)) glUniform1i(progLayout.uniformLocations.at(pair.first), texUnit);
+                texUnit++;
+            }
+
+            glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+            glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+            if (!isLastPass) {
+                currentInputTex = m_passFBOs[i].texture;
+                currentWidth = targetWidth;
+                currentHeight = targetHeight;
+            }
+        }
+        glDisable(GL_FRAMEBUFFER_SRGB);
+    }
+
+    glBindVertexArray(0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return m_outputArrayTex;
+}

--- a/src/frontend/qt_sdl/ShaderManager.h
+++ b/src/frontend/qt_sdl/ShaderManager.h
@@ -1,0 +1,102 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef SHADERMANAGER_H
+#define SHADERMANAGER_H
+
+#include "SlangPreset.h"
+#include "glad/glad.h"
+
+#include <string>
+#include <vector>
+#include <map>
+#include <mutex>
+
+struct ShaderFBO {
+    GLuint fbo = 0;
+    GLuint texture = 0;
+    int width = 0;
+    int height = 0;
+};
+
+struct UniformLayout {
+    GLuint blockIndex = GL_INVALID_INDEX;
+    GLint blockSize = 0;
+    std::map<std::string, size_t> offsets;
+};
+
+struct ProgramLayout {
+    UniformLayout globalUBO;
+    UniformLayout pushUBO;
+    std::map<std::string, GLint> uniformLocations;
+};
+
+class ShaderManager {
+public:
+    ShaderManager();
+    ~ShaderManager();
+
+    // Loads a preset immediately (called from Process() if a pending load was requested)
+    bool LoadPreset(const SlangPreset& preset);
+    // Queues a preset load to be applied on the next Process() call (thread-safe)
+    void RequestPresetLoad(const SlangPreset& preset);
+    
+    // Processes inputTexArray through all shader passes, returns filtered 2D array texture
+    GLuint Process(GLuint inputTexArray, int inputWidth, int inputHeight, int windowWidth, int windowHeight, int& outWidth, int& outHeight);
+
+    void SetParameter(const std::string& name, float value);
+
+private:
+    SlangPreset m_preset;
+    
+    bool m_presetPending = false;
+    SlangPreset m_pendingPreset;
+    std::mutex m_pendingMutex;
+    
+    ShaderFBO m_fboA;
+    ShaderFBO m_fboB;
+    GLuint m_extractFBO = 0;
+    
+    GLuint m_outputArrayFBO = 0;
+    GLuint m_outputArrayTex = 0;
+    int m_outputArrayWidth = 0;
+    int m_outputArrayHeight = 0;
+    
+    std::vector<GLuint> m_shaderPrograms;
+    std::vector<ProgramLayout> m_programLayouts;
+    std::map<std::string, float> m_parameters;
+    std::map<std::string, GLuint> m_lutTextures;
+    std::vector<ShaderFBO> m_passFBOs;
+    uint32_t m_frameCount = 0;
+
+    GLuint m_globalUBO = 0;
+    GLuint m_pushConstantsUBO = 0;
+
+    GLuint m_quadVAO = 0;
+    GLuint m_quadVBO = 0;
+
+    void InitQuad();
+    void CleanupFBOs();
+    void ResizeFBO(ShaderFBO& fbo, int width, int height, bool linearFilter, bool srgb = false, bool floatFbo = false);
+    void ResizeOutputArray(int width, int height);
+    
+    // Compiles a .slang shader to GLSL via glslang->SPIRV->spirv-cross pipeline
+    bool CompileShaderPass(const std::string& slangPath, GLuint& outProgram);
+};
+
+#endif // SHADERMANAGER_H

--- a/src/frontend/qt_sdl/ShaderParser.cpp
+++ b/src/frontend/qt_sdl/ShaderParser.cpp
@@ -1,0 +1,218 @@
+#include "ShaderParser.h"
+#include "FrontendShader.h"
+#include <QDirIterator>
+#include <QFileInfo>
+#include <QDir>
+#include <iostream>
+
+ShaderParser::ShaderParser(const std::string& shaderDir) : m_shaderDir(shaderDir) {}
+
+std::vector<FrontendShader> ShaderParser::GetPresets() {
+    std::vector<FrontendShader> presets;
+
+    // Curated list of shader presets to expose in the filter UI
+    const std::vector<std::string> curatedPaths = {
+        "edge-smoothing/xbrz/xbrz-freescale.slangp",
+        "edge-smoothing/xbrz/6xbrz-linear.slangp",
+        "edge-smoothing/xbrz/5xbrz-linear.slangp",
+        "edge-smoothing/xbrz/4xbrz-linear.slangp",
+        "edge-smoothing/scalenx/scale2x.slangp",
+        "edge-smoothing/scalenx/epx.slangp",
+        "edge-smoothing/hqx/hq2x.slangp",
+        "edge-smoothing/hqx/hq3x.slangp",
+        "edge-smoothing/hqx/hq4x.slangp",
+        "edge-smoothing/eagle/super-2xsai.slangp",
+        "edge-smoothing/eagle/supereagle.slangp",
+        "edge-smoothing/xbr/super-xbr.slangp",
+        "edge-smoothing/sabr/sabr.slangp",
+        "edge-smoothing/omniscale/omniscale.slangp",
+        "handheld/lcd-grid-v2.slangp",
+        "handheld/color-mod/nds-color.slangp",
+        "handheld/color-mod/dslite-color.slangp",
+        "handheld/zfast-lcd.slangp",
+        "handheld/gameboy.slangp",
+        "dithering/mdapt.slangp",
+        "ntsc/ntsc-256px-composite.slangp",
+        "anti-aliasing/fxaa.slangp",
+        "anti-aliasing/smaa.slangp",
+        "sharpen/adaptive-sharpen.slangp",
+        "sharpen/luma-sharpen.slangp",
+        "sharpen/Anime4k.slangp",
+        "interpolation/bicubic.slangp",
+        "interpolation/lanczos2.slangp",
+        "crt/crt-easymode.slangp",
+        "crt/crt-geom.slangp",
+        "crt/crt-lottes.slangp",
+        "crt/crt-hyllian.slangp",
+        "crt/crt-aperture.slangp",
+        "crt/crt-caligari.slangp",
+        "crt/crt-mattias.slangp"
+    };
+
+    for (const auto& relPath : curatedPaths) {
+        std::string fullPath = QDir(QString::fromStdString(m_shaderDir)).filePath(QString::fromStdString(relPath)).toStdString();
+        QFileInfo fileInfo(QString::fromStdString(fullPath));
+
+        if (!fileInfo.exists()) continue;
+
+        FrontendShader feShader;
+        if (feShader.preset.load(fullPath)) {
+            feShader.path = fullPath;
+            
+            if (relPath.find("xbrz-freescale") != std::string::npos) {
+                feShader.name = "xBRZ Freescale (Auto)";
+                feShader.author = "Zenju / libretro";
+                feShader.description = "xBRZ upscales images by detecting edges and drawing smooth lines. Good for 2D pixel art.";
+            } else if (relPath.find("6xbrz") != std::string::npos) {
+                feShader.name = "xBRZ 6x";
+                feShader.author = "Zenju / libretro";
+                feShader.description = "Fixed 6x pass xBRZ upscaler for pixel art edge smoothing.";
+            } else if (relPath.find("5xbrz") != std::string::npos) {
+                feShader.name = "xBRZ 5x";
+                feShader.author = "Zenju / libretro";
+                feShader.description = "Fixed 5x pass xBRZ upscaler for pixel art edge smoothing.";
+            } else if (relPath.find("4xbrz") != std::string::npos) {
+                feShader.name = "xBRZ 4x";
+                feShader.author = "Zenju / libretro";
+                feShader.description = "Fixed 4x pass xBRZ upscaler for pixel art edge smoothing.";
+            } else if (relPath.find("scale2x") != std::string::npos) {
+                feShader.name = "Scale2x";
+                feShader.author = "Andrea Mazzoleni";
+                feShader.description = "A fast pixel art scaler that smooths jagged edges without blurring.";
+            } else if (relPath.find("epx") != std::string::npos) {
+                feShader.name = "EPX";
+                feShader.author = "Eric Johnston";
+                feShader.description = "Eric's Pixel Expansion. A fast 2x upscaler developed originally for LucasArts.";
+            } else if (relPath.find("hq2x") != std::string::npos) {
+                feShader.name = "HQ2x";
+                feShader.author = "Maxim Stepin";
+                feShader.description = "High Quality 2x upscaler that interpolates edges to preserve pixel art details smoothly.";
+            } else if (relPath.find("hq3x") != std::string::npos) {
+                feShader.name = "HQ3x";
+                feShader.author = "Maxim Stepin";
+                feShader.description = "High Quality 3x upscaler that interpolates edges to preserve pixel art details smoothly.";
+            } else if (relPath.find("hq4x") != std::string::npos) {
+                feShader.name = "HQ4x";
+                feShader.author = "Maxim Stepin";
+                feShader.description = "High Quality 4x upscaler that interpolates edges to preserve pixel art details smoothly.";
+            } else if (relPath.find("super-2xsai") != std::string::npos) {
+                feShader.name = "Super 2xSaI";
+                feShader.author = "Derek Liauw Kie Fa";
+                feShader.description = "Super 2x Scale and Interpolate. A classic emulator pixel art upscaler.";
+            } else if (relPath.find("supereagle") != std::string::npos) {
+                feShader.name = "Super Eagle";
+                feShader.author = "Derek Liauw Kie Fa";
+                feShader.description = "An early scale engine that creates a slightly blurrier, smoothly blended upscale.";
+            } else if (relPath.find("super-xbr") != std::string::npos) {
+                feShader.name = "Super-xBR";
+                feShader.author = "Hyllian";
+                feShader.description = "Advanced edge-directed interpolation filter to smoothly upscale images.";
+            } else if (relPath.find("sabr") != std::string::npos) {
+                feShader.name = "SABR";
+                feShader.author = "Joshua Street";
+                feShader.description = "Shape Anti-Aliasing by Bicubic Interpolation. Great for smoothing out pixel graphics.";
+            } else if (relPath.find("omniscale") != std::string::npos) {
+                feShader.name = "OmniScale";
+                feShader.author = "Lior Halphon";
+                feShader.description = "A scale-independent 2D upscale filter based on edge-directed interpolation.";
+            } else if (relPath.find("nds-color") != std::string::npos) {
+                feShader.name = "NDS Color";
+                feShader.author = "pokefan531";
+                feShader.description = "Adjusts gamma and color profile to simulate the washed-out look of the original Nintendo DS hardware.";
+            } else if (relPath.find("dslite-color") != std::string::npos) {
+                feShader.name = "DS-Lite Color";
+                feShader.author = "pokefan531";
+                feShader.description = "Simulates the specific screen color temperature and gamma of the Nintendo DS Lite hardware.";
+            } else if (relPath.find("lcd-grid-v2") != std::string::npos) {
+                feShader.name = "LCD Grid v2";
+                feShader.author = "cgwg";
+                feShader.description = "Simulates an LCD pixel grid typical of classic handheld consoles.";
+            } else if (relPath.find("zfast-lcd") != std::string::npos) {
+                feShader.name = "zFast LCD";
+                feShader.author = "SoltanGris42";
+                feShader.description = "A fast shader that accurately emulates the subtle ghosting and LCD grid of handheld screens.";
+            } else if (relPath.find("gameboy") != std::string::npos) {
+                feShader.name = "GameBoy DMG";
+                feShader.author = "cgwg / libretro";
+                feShader.description = "Emulates the iconic dot matrix grid and greenish tint of the original GameBoy hardware.";
+            } else if (relPath.find("mdapt") != std::string::npos) {
+                feShader.name = "MDAPT Dithering";
+                feShader.author = "Sp00kyFox";
+                feShader.description = "Merge Dithering and Pseudo-Transparency. Smartly blends checkerboard dithering patterns.";
+            } else if (relPath.find("ntsc-256px-composite") != std::string::npos) {
+                feShader.name = "NTSC Composite";
+                feShader.author = "Themaister";
+                feShader.description = "Simulates the artifacts, color bleeding, and fringing of a classic composite video signal.";
+            } else if (relPath.find("fxaa") != std::string::npos) {
+                feShader.name = "FXAA";
+                feShader.author = "Timothy Lottes";
+                feShader.description = "Fast Approximate Anti-Aliasing. A very fast screen-space anti-aliasing technique for 3D edges.";
+            } else if (relPath.find("smaa") != std::string::npos) {
+                feShader.name = "SMAA";
+                feShader.author = "Jorge Jimenez";
+                feShader.description = "Subpixel Morphological Anti-Aliasing. Advanced technique for smoothing 3D polygon edges.";
+            } else if (relPath.find("adaptive-sharpen") != std::string::npos) {
+                feShader.name = "Adaptive Sharpen";
+                feShader.author = "bakamac";
+                feShader.description = "Dynamically sharpens images while preserving delicate details.";
+            } else if (relPath.find("luma-sharpen") != std::string::npos) {
+                feShader.name = "Luma Sharpen";
+                feShader.author = "CeeJay.dk";
+                feShader.description = "Sharpens the image using the luma channel to prevent color artifacts.";
+            } else if (relPath.find("Anime4k") != std::string::npos) {
+                feShader.name = "Anime4K";
+                feShader.author = "bloc97";
+                feShader.description = "State-of-the-art open-source high-quality real-time anime upscaling algorithm.";
+            } else if (relPath.find("bicubic") != std::string::npos) {
+                feShader.name = "Bicubic";
+                feShader.author = "libretro";
+                feShader.description = "Standard mathematical interpolation filter for smooth upscaling.";
+            } else if (relPath.find("lanczos2") != std::string::npos) {
+                feShader.name = "Lanczos2";
+                feShader.author = "libretro";
+                feShader.description = "High-quality resampling filter using a Lanczos window.";
+            } else if (relPath.find("crt-easymode") != std::string::npos) {
+                feShader.name = "CRT EasyMode";
+                feShader.author = "Easymode";
+                feShader.description = "A simple and clean CRT shader that provides a nice classic TV scanline look.";
+            } else if (relPath.find("crt-geom") != std::string::npos) {
+                feShader.name = "CRT Geom";
+                feShader.author = "cgwg";
+                feShader.description = "Simulates the screen curvature, glow, and scanlines of a classic CRT monitor.";
+            } else if (relPath.find("crt-lottes") != std::string::npos) {
+                feShader.name = "CRT Lottes";
+                feShader.author = "Timothy Lottes";
+                feShader.description = "Emulates the distinct shadow mask and scanline look of an old-school CRT TV.";
+            } else if (relPath.find("crt-hyllian") != std::string::npos) {
+                feShader.name = "CRT Hyllian";
+                feShader.author = "Hyllian";
+                feShader.description = "A high-quality CRT shader designed to preserve sharpness while adding scanlines and phosphor masks.";
+            } else if (relPath.find("crt-aperture") != std::string::npos) {
+                feShader.name = "CRT Aperture";
+                feShader.author = "Wozniak";
+                feShader.description = "A moderately heavy shader simulating Sony Trinitron aperture grille CRT TVs.";
+            } else if (relPath.find("crt-caligari") != std::string::npos) {
+                feShader.name = "CRT Caligari";
+                feShader.author = "Caligari";
+                feShader.description = "A sharp CRT shader that uses simple mathematics to simulate scanlines and shadow mask.";
+            } else if (relPath.find("crt-mattias") != std::string::npos) {
+                feShader.name = "CRT Mattias";
+                feShader.author = "Mattias Gustavsson";
+                feShader.description = "Simulates an old, distorted, slightly curved CRT screen with heavy color bleeding.";
+            } else {
+                // Fallback for any preset not explicitly named above
+                feShader.name = fileInfo.baseName().toStdString();
+                feShader.author = "Unknown";
+                feShader.description = "No description available.";
+            }
+            
+            presets.push_back(feShader);
+        }
+    }
+
+    std::sort(presets.begin(), presets.end(), [](const FrontendShader& a, const FrontendShader& b) {
+        return a.name < b.name;
+    });
+
+    return presets;
+}

--- a/src/frontend/qt_sdl/ShaderParser.h
+++ b/src/frontend/qt_sdl/ShaderParser.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "FrontendShader.h"
+#include <string>
+#include <vector>
+
+class ShaderParser {
+public:
+    explicit ShaderParser(const std::string& shaderDir);
+    std::vector<FrontendShader> GetPresets();
+
+private:
+    std::string m_shaderDir;
+};

--- a/src/frontend/qt_sdl/SlangPreset.cpp
+++ b/src/frontend/qt_sdl/SlangPreset.cpp
@@ -1,0 +1,283 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include "SlangPreset.h"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <algorithm>
+#include <map>
+#include <regex>
+
+SlangPreset::SlangPreset() = default;
+
+SlangPreset::~SlangPreset() = default;
+
+std::string SlangPreset::trim(const std::string& str) {
+    size_t first = str.find_first_not_of(" \t\r\n");
+    if (std::string::npos == first) {
+        return "";
+    }
+    size_t last = str.find_last_not_of(" \t\r\n");
+    return str.substr(first, (last - first + 1));
+}
+
+std::string SlangPreset::removeQuotes(const std::string& str) {
+    std::string res = str;
+    if (res.length() >= 2 && res.front() == '"' && res.back() == '"') {
+        res = res.substr(1, res.length() - 2);
+    }
+    return res;
+}
+
+void SlangPreset::parsePragmasRecursive(const std::string& filePath, const std::string& baseDir, std::vector<std::string>& visited) {
+    std::ifstream shaderFile(filePath);
+    if (!shaderFile.is_open()) return;
+
+    std::regex pragmaRegex("#pragma\\s+parameter\\s+([^\\s]+)\\s+\"([^\"]+)\"\\s+([-+]?[0-9]*\\.?[0-9]+)\\s+([-+]?[0-9]*\\.?[0-9]+)\\s+([-+]?[0-9]*\\.?[0-9]+)\\s+([-+]?[0-9]*\\.?[0-9]+)");
+    std::regex includeRegex("#include\\s+\"([^\"]+)\"");
+
+    std::string line;
+    while (std::getline(shaderFile, line)) {
+        std::smatch match;
+        if (std::regex_search(line, match, pragmaRegex)) {
+            try {
+                SlangParameter param;
+                param.name = match[1];
+                param.description = match[2];
+                param.defaultValue = std::stof(match[3]);
+                param.minValue = std::stof(match[4]);
+                param.maxValue = std::stof(match[5]);
+                param.step = std::stof(match[6]);
+
+                // 10x range expansion for extra slider flexibility
+                if (param.minValue >= 0.0f) {
+                    param.maxValue *= 10.0f;
+                } else if (param.minValue < 0.0f && param.maxValue > 0.0f) {
+                    param.minValue *= 5.0f;
+                    param.maxValue *= 5.0f;
+                } else if (param.maxValue <= 0.0f) {
+                    param.minValue *= 10.0f;
+                }
+
+                m_pragma_parameters.push_back(param);
+            } catch (...) {}
+        } else if (std::regex_search(line, match, includeRegex)) {
+            std::string includePath = baseDir + "/" + match[1].str();
+            
+            if (std::find(visited.begin(), visited.end(), includePath) == visited.end()) {
+                visited.push_back(includePath);
+                parsePragmasRecursive(includePath, baseDir, visited);
+            }
+        }
+    }
+}
+
+void SlangPreset::appendPassesFrom(const SlangPreset& other) {
+    for (const auto& pass : other.m_passes) {
+        SlangShaderPass newPass = pass;
+        newPass.alias = "";
+        m_passes.push_back(newPass);
+    }
+    for (const auto& lut : other.m_luts) {
+        bool found = false;
+        for (const auto& existing : m_luts) {
+            if (existing.id == lut.id) { found = true; break; }
+        }
+        if (!found) m_luts.push_back(lut);
+    }
+    for (const auto& [key, val] : other.m_parameters) {
+        m_parameters[key] = val;
+    }
+    for (const auto& pparam : other.m_pragma_parameters) {
+        bool found = false;
+        for (auto& existing : m_pragma_parameters) {
+            if (existing.name == pparam.name) {
+                existing = pparam;
+                found = true;
+                break;
+            }
+        }
+        if (!found) m_pragma_parameters.push_back(pparam);
+    }
+}
+
+bool SlangPreset::load(const std::string& filename) {
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        std::cerr << "Failed to open slangp file: " << filename << std::endl;
+        return false;
+    }
+
+    std::string baseDir = "";
+    size_t lastSlash = filename.find_last_of("/\\");
+    if (lastSlash != std::string::npos) {
+        baseDir = filename.substr(0, lastSlash + 1);
+    }
+
+    clear();
+    std::map<std::string, std::string> config;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        line = trim(line);
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+
+        size_t equalPos = line.find('=');
+        if (equalPos != std::string::npos) {
+            std::string key = trim(line.substr(0, equalPos));
+            std::string value = trim(line.substr(equalPos + 1));
+            value = removeQuotes(value);
+            config[key] = value;
+        }
+    }
+
+    int numShaders = 0;
+    if (config.find("shaders") != config.end()) {
+        try {
+            numShaders = std::stoi(config["shaders"]);
+        } catch (const std::exception& e) {
+            std::cerr << "Invalid shaders count: " << config["shaders"] << std::endl;
+            return false;
+        }
+    }
+
+    for (int i = 0; i < numShaders; ++i) {
+        SlangShaderPass pass;
+        std::string prefix = std::to_string(i);
+
+        if (config.find("shader" + prefix) != config.end()) {
+            std::string path = config["shader" + prefix];
+            if (!path.empty() && path[0] != '/' && path[0] != '\\' && path.find(":") == std::string::npos) {
+                pass.shaderPath = baseDir + path;
+            } else {
+                pass.shaderPath = path;
+            }
+        } else {
+            std::cerr << "Missing shader path for pass " << i << std::endl;
+            continue;
+        }
+
+        if (config.find("filter_linear" + prefix) != config.end()) {
+            pass.filterLinear = (config["filter_linear" + prefix] == "true");
+        }
+        
+        if (config.find("srgb_framebuffer" + prefix) != config.end()) {
+            pass.srgbFramebuffer = (config["srgb_framebuffer" + prefix] == "true");
+        }
+
+        if (config.find("float_framebuffer" + prefix) != config.end()) {
+            pass.floatFramebuffer = (config["float_framebuffer" + prefix] == "true");
+        }
+
+        if (config.find("alias" + prefix) != config.end()) {
+            pass.alias = config["alias" + prefix];
+        }
+
+        if (config.find("scale_type" + prefix) != config.end()) {
+            pass.scaleTypeX = config["scale_type" + prefix];
+            pass.scaleTypeY = config["scale_type" + prefix];
+        }
+        if (config.find("scale_type_x" + prefix) != config.end()) {
+            pass.scaleTypeX = config["scale_type_x" + prefix];
+        }
+        if (config.find("scale_type_y" + prefix) != config.end()) {
+            pass.scaleTypeY = config["scale_type_y" + prefix];
+        }
+
+        try {
+            if (config.find("scale" + prefix) != config.end()) {
+                pass.scaleX = std::stof(config["scale" + prefix]);
+                pass.scaleY = pass.scaleX;
+            }
+            if (config.find("scale_x" + prefix) != config.end()) {
+                pass.scaleX = std::stof(config["scale_x" + prefix]);
+            }
+            if (config.find("scale_y" + prefix) != config.end()) {
+                pass.scaleY = std::stof(config["scale_y" + prefix]);
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Invalid scale value for pass " << i << std::endl;
+        }
+
+        size_t lastSlashPragma = pass.shaderPath.find_last_of("/\\");
+        std::string shaderBaseDir = (lastSlashPragma == std::string::npos) ? "." : pass.shaderPath.substr(0, lastSlashPragma);
+        std::vector<std::string> visited;
+        parsePragmasRecursive(pass.shaderPath, shaderBaseDir, visited);
+
+        m_passes.push_back(pass);
+    }
+
+    // Deduplicate parameters that appear in multiple passes via shared #include files (e.g. gb-params.inc)
+    {
+        std::map<std::string, SlangParameter> deduped;
+        for (const auto& p : m_pragma_parameters) {
+            deduped[p.name] = p;
+        }
+        m_pragma_parameters.clear();
+        for (const auto& [name, p] : deduped) {
+            m_pragma_parameters.push_back(p);
+        }
+    }
+
+    if (config.find("textures") != config.end()) {
+        std::stringstream ss(config["textures"]);
+        std::string textureId;
+        while (std::getline(ss, textureId, ';')) {
+            textureId = trim(textureId);
+            if (textureId.empty()) continue;
+
+            if (config.find(textureId) != config.end()) {
+                SlangLUT lut;
+                lut.id = textureId;
+                std::string path = config[textureId];
+                if (!path.empty() && path[0] != '/' && path[0] != '\\' && path.find(":") == std::string::npos) {
+                    lut.path = baseDir + path;
+                } else {
+                    lut.path = path;
+                }
+                
+                if (config.find(textureId + "_linear") != config.end()) {
+                    lut.linear = (config[textureId + "_linear"] == "true");
+                }
+                m_luts.push_back(lut);
+            }
+        }
+    }
+
+    for (const auto& [key, value] : config) {
+        if (key == "shaders" || key == "textures" || 
+            key.find("shader") == 0 || key.find("filter_linear") == 0 || 
+            key.find("srgb_framebuffer") == 0 || key.find("scale_type") == 0 || 
+            key.find("scale") == 0 || key.find("alias") == 0 || 
+            key.find("wrap_mode") == 0 || key.find("mipmap_input") == 0 || 
+            key.find("float_framebuffer") == 0 || key.find("frame_count_mod") == 0) {
+            continue;
+        }
+        
+        try {
+            float val = std::stof(value);
+            m_parameters[key] = val;
+        } catch (...) {
+        }
+    }
+
+    return true;
+}

--- a/src/frontend/qt_sdl/SlangPreset.h
+++ b/src/frontend/qt_sdl/SlangPreset.h
@@ -1,0 +1,80 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef SLANGPRESET_H
+#define SLANGPRESET_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+struct SlangParameter {
+    std::string name;
+    std::string description;
+    float defaultValue;
+    float minValue;
+    float maxValue;
+    float step;
+};
+
+struct SlangShaderPass {
+    std::string shaderPath;
+    std::string alias;
+    std::string scaleTypeX = "source";
+    std::string scaleTypeY = "source";
+    float scaleX = 1.0f;
+    float scaleY = 1.0f;
+
+    bool filterLinear = false;
+    bool srgbFramebuffer = false;
+    bool floatFramebuffer = false;
+};
+
+struct SlangLUT {
+    std::string id;
+    std::string path;
+    bool linear = false;
+};
+
+class SlangPreset {
+public:
+    SlangPreset();
+    ~SlangPreset();
+
+    bool load(const std::string& filename);
+    const std::vector<SlangShaderPass>& getPasses() const { return m_passes; }
+    const std::vector<SlangLUT>& getLUTs() const { return m_luts; }
+    const std::map<std::string, float>& getParameters() const { return m_parameters; }
+    const std::vector<SlangParameter>& getPragmaParameters() const { return m_pragma_parameters; }
+    void clear() { m_passes.clear(); m_luts.clear(); m_parameters.clear(); m_pragma_parameters.clear(); }
+    // Concatenates passes from another preset into this one, merging LUTs and parameters. (used for stacking filters)
+    void appendPassesFrom(const SlangPreset& other);
+
+private:
+    std::vector<SlangShaderPass> m_passes;
+    std::vector<SlangLUT> m_luts;
+    std::map<std::string, float> m_parameters;
+    std::vector<SlangParameter> m_pragma_parameters;
+
+    std::string trim(const std::string& str);
+    std::string removeQuotes(const std::string& str);
+    // Recursively parses #pragma parameter directives from a .slang file and its #include tree
+    void parsePragmasRecursive(const std::string& filePath, const std::string& baseDir, std::vector<std::string>& visited);
+};
+
+#endif // SLANGPRESET_H

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -572,7 +572,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             actScreenFiltering = menu->addAction("Screen filtering");
             actScreenFiltering->setCheckable(true);
             connect(actScreenFiltering, &QAction::triggered, this, &MainWindow::onChangeScreenFiltering);
-            
+
             actFilters = menu->addAction("Filters");
             connect(actFilters, &QAction::triggered, this, &MainWindow::onOpenFilterConfig);
 
@@ -733,7 +733,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
         }
 
         actScreenFiltering->setChecked(windowCfg.GetBool("ScreenFilter"));
-        
+
         actShowOSD->setChecked(showOSD);
 
         actLimitFramerate->setChecked(emuInstance->doLimitFPS);
@@ -2311,7 +2311,7 @@ void MainWindow::onUpdateVideoSettings(bool glchange)
 
     if (glchange)
     {
-        if (hasOGL) 
+        if (hasOGL)
         {
             emuThread->initContext(windowID);
             for (auto child: childwins)
@@ -2337,11 +2337,16 @@ void MainWindow::onOpenFilterConfig()
         return;
     }
 
-    ShaderParser parser("res/slang-shaders");
+    QString shaderPath = QCoreApplication::applicationDirPath() + "/res/slang-shaders";
+    if (!QDir(shaderPath).exists()) {
+            shaderPath = QCoreApplication::applicationDirPath() + "/../res/slang-shaders";
+    }
+    std::string pathStd = shaderPath.toStdString();
+
+    ShaderParser parser(pathStd.c_str());
     std::vector<FrontendShader> presets = parser.GetPresets();
 
     ShaderConfigDialog* dlg = new ShaderConfigDialog(sm, presets, this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->show();
 }
-

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2341,6 +2341,12 @@ void MainWindow::onOpenFilterConfig()
     if (!QDir(shaderPath).exists()) {
             shaderPath = QCoreApplication::applicationDirPath() + "/../res/slang-shaders";
     }
+    #ifdef Q_OS_MAC
+        if (!QDir(shaderPath).exists()) {
+            shaderPath = QCoreApplication::applicationDirPath() + "/../Resources/res/slang-shaders";
+        }
+    #endif
+
     std::string pathStd = shaderPath.toStdString();
 
     ShaderParser parser(pathStd.c_str());

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -58,6 +58,8 @@
 #include "ROMInfoDialog.h"
 #include "RAMInfoDialog.h"
 #include "TitleManagerDialog.h"
+#include "ShaderConfigDialog.h"
+#include "ShaderParser.h"
 #include "PowerManagement/PowerManagementDialog.h"
 
 #include "Platform.h"
@@ -570,6 +572,9 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             actScreenFiltering = menu->addAction("Screen filtering");
             actScreenFiltering->setCheckable(true);
             connect(actScreenFiltering, &QAction::triggered, this, &MainWindow::onChangeScreenFiltering);
+            
+            actFilters = menu->addAction("Filters");
+            connect(actFilters, &QAction::triggered, this, &MainWindow::onOpenFilterConfig);
 
             actShowOSD = menu->addAction("Show OSD");
             actShowOSD->setCheckable(true);
@@ -728,6 +733,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
         }
 
         actScreenFiltering->setChecked(windowCfg.GetBool("ScreenFilter"));
+        
         actShowOSD->setChecked(showOSD);
 
         actLimitFramerate->setChecked(emuInstance->doLimitFPS);
@@ -2321,3 +2327,21 @@ void MainWindow::onUpdateVideoSettings(bool glchange)
         emuThread->emuUnpause();
     }
 }
+
+void MainWindow::onOpenFilterConfig()
+{
+    ShaderManager* sm = panel->getShaderManager();
+    if (!sm)
+    {
+        QMessageBox::warning(this, "Shader Configuration", "Shaders are only available when 'Screen filtering' (OpenGL renderer) is enabled.\n\nPlease enable it in Config -> Video settings.");
+        return;
+    }
+
+    ShaderParser parser("res/slang-shaders");
+    std::vector<FrontendShader> presets = parser.GetPresets();
+
+    ShaderConfigDialog* dlg = new ShaderConfigDialog(sm, presets, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->show();
+}
+

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -169,6 +169,8 @@ private slots:
     void onChangeIntegerScaling(bool checked);
     void onOpenNewWindow();
     void onChangeScreenFiltering(bool checked);
+    void onOpenFilterConfig();
+    
     void onChangeShowOSD(bool checked);
     void onChangeLimitFramerate(bool checked);
     void onChangeAudioSync(bool checked);
@@ -291,6 +293,7 @@ public:
     QAction** actScreenAspectBot;
     QAction* actNewWindow;
     QAction* actScreenFiltering;
+    QAction* actFilters;
     QAction* actShowOSD;
     QAction* actLimitFramerate;
     QAction* actAudioSync;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,93 +1,108 @@
 {
-	"vcpkg-configuration": {
-		"default-registry": {
-			"kind": "git",
-			"repository": "https://github.com/Microsoft/vcpkg",
-			"baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
-			"reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
-		},
-		"overlay-ports": [ "./cmake/overlay-ports" ],
-		"overlay-triplets": [ "./cmake/overlay-triplets" ]
-	},
-	"default-features": ["qt6"],
-	"dependencies": [
-		"sdl2",
-		{
-			"name": "sdl2",
-			"platform": "linux",
-			"features": [ "alsa" ]
-		},
-		"libarchive",
-		"zstd",
-		"enet",
-		{
-			"name": "ecm",
-			"platform": "linux"
-		},
-		{
-			"name": "libslirp",
-			"platform": "linux"
-		},
-		"faad2",
-		"pkgconf",
-		{ "name": "pkgconf", "host": true },
-		{ "name": "dirent", "platform": "windows" },
-		{
-			"name": "dbus",
-			"platform": "linux",
-			"default-features": false
-		},
-		"glslang",
-		"spirv-cross"
-	],
-	"features": {
-		"qt6": {
-			"description": "Use Qt 6 for the frontend.",
-			"dependencies": [
-				{
-					"name": "qtbase",
-					"default-features": false,
-					"features": ["gui", "png", "thread", "widgets", "opengl", "zstd", "harfbuzz"]
-				},
-				{
-					"name": "qtbase",
-					"platform": "linux",
-					"default-features": false,
-					"features": ["dbus", "xcb", "xkb", "xcb-xlib", "freetype", "fontconfig"]
-				},
-				{
-					"name": "qtbase",
-					"host": true,
-					"default-features": false
-				},
-				{
-					"name": "qtmultimedia",
-					"default-features": false
-				},
-				{
-					"name": "qtmultimedia",
-					"platform": "linux",
-					"features": ["gstreamer"],
-					"default-features": false
-				},
-				"qtsvg"
-			]
-		},
-		"qt5": {
-			"description": "Use Qt 5 for the frontend.",
-			"dependencies": [
-				{
-					"name": "qt5-base",
-					"default-features": false
-				},
-				{
-					"name": "qt5-base",
-					"host": true,
-					"default-features": false
-				},
-				"qt5-multimedia",
-				"qt5-svg"
-			]
-		}
-	}
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "repository": "https://github.com/Microsoft/vcpkg",
+      "baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
+      "reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
+    },
+    "overlay-ports": ["./cmake/overlay-ports"],
+    "overlay-triplets": ["./cmake/overlay-triplets"]
+  },
+  "default-features": ["qt6"],
+  "dependencies": [
+    "sdl2",
+    {
+      "name": "sdl2",
+      "platform": "linux",
+      "features": ["alsa"]
+    },
+    "libarchive",
+    "zstd",
+    "enet",
+    {
+      "name": "ecm",
+      "platform": "linux"
+    },
+    {
+      "name": "libslirp",
+      "platform": "linux"
+    },
+    "faad2",
+    "pkgconf",
+    { "name": "pkgconf", "host": true },
+    { "name": "dirent", "platform": "windows" },
+    {
+      "name": "dbus",
+      "platform": "linux",
+      "default-features": false
+    },
+    "glslang",
+    "spirv-cross"
+  ],
+  "features": {
+    "qt6": {
+      "description": "Use Qt 6 for the frontend.",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "gui",
+            "png",
+            "thread",
+            "widgets",
+            "opengl",
+            "zstd",
+            "harfbuzz"
+          ]
+        },
+        {
+          "name": "qtbase",
+          "platform": "linux",
+          "default-features": false,
+          "features": [
+            "dbus",
+            "xcb",
+            "xkb",
+            "xcb-xlib",
+            "freetype",
+            "fontconfig"
+          ]
+        },
+        {
+          "name": "qtbase",
+          "host": true,
+          "default-features": false
+        },
+        {
+          "name": "qtmultimedia",
+          "default-features": false
+        },
+        {
+          "name": "qtmultimedia",
+          "platform": "linux",
+          "features": ["gstreamer"],
+          "default-features": false
+        },
+        "qtsvg"
+      ]
+    },
+    "qt5": {
+      "description": "Use Qt 5 for the frontend.",
+      "dependencies": [
+        {
+          "name": "qt5-base",
+          "default-features": false
+        },
+        {
+          "name": "qt5-base",
+          "host": true,
+          "default-features": false
+        },
+        "qt5-multimedia",
+        "qt5-svg"
+      ]
+    }
+  }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
     "overlay-ports": ["./cmake/overlay-ports"],
     "overlay-triplets": ["./cmake/overlay-triplets"]
   },
-  "default-features": [],
+  "default-features": ["qt6"],
   "dependencies": [
     "sdl2",
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,107 +1,93 @@
 {
-  "vcpkg-configuration": {
-    "default-registry": {
-      "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg",
-      "baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
-      "reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
-    },
-    "overlay-ports": ["./cmake/overlay-ports"],
-    "overlay-triplets": ["./cmake/overlay-triplets"]
-  },
-  "default-features": ["qt6"],
-  "dependencies": [
-    "sdl2",
-    {
-      "name": "sdl2",
-      "platform": "linux",
-      "features": ["alsa"]
-    },
-    "libarchive",
-    "zstd",
-    "enet",
-    {
-      "name": "ecm",
-      "platform": "linux"
-    },
-    {
-      "name": "libslirp",
-      "platform": "linux"
-    },
-    "faad2",
-    "pkgconf",
-    { "name": "pkgconf", "host": true },
-    { "name": "dirent", "platform": "windows" },
-    {
-      "name": "dbus",
-      "default-features": false
-    },
-    "glslang",
-    "spirv-cross"
-  ],
-  "features": {
-    "qt6": {
-      "description": "Use Qt 6 for the frontend.",
-      "dependencies": [
-        {
-          "name": "qtbase",
-          "default-features": false,
-          "features": [
-            "gui",
-            "png",
-            "thread",
-            "widgets",
-            "opengl",
-            "zstd",
-            "harfbuzz"
-          ]
-        },
-        {
-          "name": "qtbase",
-          "platform": "linux",
-          "default-features": false,
-          "features": [
-            "dbus",
-            "xcb",
-            "xkb",
-            "xcb-xlib",
-            "freetype",
-            "fontconfig"
-          ]
-        },
-        {
-          "name": "qtbase",
-          "host": true,
-          "default-features": false
-        },
-        {
-          "name": "qtmultimedia",
-          "default-features": false
-        },
-        {
-          "name": "qtmultimedia",
-          "platform": "linux",
-          "features": ["gstreamer"],
-          "default-features": false
-        },
-        "qtsvg"
-      ]
-    },
-    "qt5": {
-      "description": "Use Qt 5 for the frontend.",
-      "dependencies": [
-        {
-          "name": "qt5-base",
-          "default-features": false
-        },
-        {
-          "name": "qt5-base",
-          "host": true,
-          "default-features": false
-        },
-        "qt5-multimedia",
-        "qt5-svg"
-      ]
-    }
-  }
+	"vcpkg-configuration": {
+		"default-registry": {
+			"kind": "git",
+			"repository": "https://github.com/Microsoft/vcpkg",
+			"baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
+			"reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
+		},
+		"overlay-ports": [ "./cmake/overlay-ports" ],
+		"overlay-triplets": [ "./cmake/overlay-triplets" ]
+	},
+	"default-features": ["qt6"],
+	"dependencies": [
+		"sdl2",
+		{
+			"name": "sdl2",
+			"platform": "linux",
+			"features": [ "alsa" ]
+		},
+		"libarchive",
+		"zstd",
+		"enet",
+		{
+			"name": "ecm",
+			"platform": "linux"
+		},
+		{
+			"name": "libslirp",
+			"platform": "linux"
+		},
+		"faad2",
+		"pkgconf",
+		{ "name": "pkgconf", "host": true },
+		{ "name": "dirent", "platform": "windows" },
+		{
+			"name": "dbus",
+			"platform": "linux",
+			"default-features": false
+		},
+		"glslang",
+		"spirv-cross"
+	],
+	"features": {
+		"qt6": {
+			"description": "Use Qt 6 for the frontend.",
+			"dependencies": [
+				{
+					"name": "qtbase",
+					"default-features": false,
+					"features": ["gui", "png", "thread", "widgets", "opengl", "zstd", "harfbuzz"]
+				},
+				{
+					"name": "qtbase",
+					"platform": "linux",
+					"default-features": false,
+					"features": ["dbus", "xcb", "xkb", "xcb-xlib", "freetype", "fontconfig"]
+				},
+				{
+					"name": "qtbase",
+					"host": true,
+					"default-features": false
+				},
+				{
+					"name": "qtmultimedia",
+					"default-features": false
+				},
+				{
+					"name": "qtmultimedia",
+					"platform": "linux",
+					"features": ["gstreamer"],
+					"default-features": false
+				},
+				"qtsvg"
+			]
+		},
+		"qt5": {
+			"description": "Use Qt 5 for the frontend.",
+			"dependencies": [
+				{
+					"name": "qt5-base",
+					"default-features": false
+				},
+				{
+					"name": "qt5-base",
+					"host": true,
+					"default-features": false
+				},
+				"qt5-multimedia",
+				"qt5-svg"
+			]
+		}
+	}
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,86 +1,107 @@
 {
-	"vcpkg-configuration": {
-		"default-registry": {
-			"kind": "git",
-			"repository": "https://github.com/Microsoft/vcpkg",
-			"baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
-			"reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
-		},
-		"overlay-ports": [ "./cmake/overlay-ports" ],
-		"overlay-triplets": [ "./cmake/overlay-triplets" ]
-	},
-	"default-features": ["qt6"],
-	"dependencies": [
-		"sdl2",
-		{
-			"name": "sdl2",
-			"platform": "linux",
-			"features": [ "alsa" ]
-		},
-		"libarchive",
-		"zstd",
-		"enet",
-		{
-			"name": "ecm",
-			"platform": "linux"
-		},
-		{
-			"name": "libslirp",
-			"platform": "linux"
-		},
-		"faad2",
-		"pkgconf",
-		{ "name": "pkgconf", "host": true },
-		{ "name": "dirent", "platform": "windows" }
-	],
-	"features": {
-		"qt6": {
-			"description": "Use Qt 6 for the frontend.",
-			"dependencies": [
-				{
-					"name": "qtbase",
-					"default-features": false,
-					"features": ["gui", "png", "thread", "widgets", "opengl", "zstd", "harfbuzz"]
-				},
-				{
-					"name": "qtbase",
-					"platform": "linux",
-					"default-features": false,
-					"features": ["dbus", "xcb", "xkb", "xcb-xlib", "freetype", "fontconfig"]
-				},
-				{
-					"name": "qtbase",
-					"host": true,
-					"default-features": false
-				},
-				{
-					"name": "qtmultimedia",
-					"default-features": false
-				},
-				{
-					"name": "qtmultimedia",
-					"platform": "linux",
-					"features": ["gstreamer"],
-					"default-features": false
-				},
-				"qtsvg"
-			]
-		},
-		"qt5": {
-			"description": "Use Qt 5 for the frontend.",
-			"dependencies": [
-				{
-					"name": "qt5-base",
-					"default-features": false
-				},
-				{
-					"name": "qt5-base",
-					"host": true,
-					"default-features": false
-				},
-				"qt5-multimedia",
-				"qt5-svg"
-			]
-		}
-	}
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "repository": "https://github.com/Microsoft/vcpkg",
+      "baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d",
+      "reference": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
+    },
+    "overlay-ports": ["./cmake/overlay-ports"],
+    "overlay-triplets": ["./cmake/overlay-triplets"]
+  },
+  "default-features": [],
+  "dependencies": [
+    "sdl2",
+    {
+      "name": "sdl2",
+      "platform": "linux",
+      "features": ["alsa"]
+    },
+    "libarchive",
+    "zstd",
+    "enet",
+    {
+      "name": "ecm",
+      "platform": "linux"
+    },
+    {
+      "name": "libslirp",
+      "platform": "linux"
+    },
+    "faad2",
+    "pkgconf",
+    { "name": "pkgconf", "host": true },
+    { "name": "dirent", "platform": "windows" },
+    {
+      "name": "dbus",
+      "default-features": false
+    },
+    "glslang",
+    "spirv-cross"
+  ],
+  "features": {
+    "qt6": {
+      "description": "Use Qt 6 for the frontend.",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "gui",
+            "png",
+            "thread",
+            "widgets",
+            "opengl",
+            "zstd",
+            "harfbuzz"
+          ]
+        },
+        {
+          "name": "qtbase",
+          "platform": "linux",
+          "default-features": false,
+          "features": [
+            "dbus",
+            "xcb",
+            "xkb",
+            "xcb-xlib",
+            "freetype",
+            "fontconfig"
+          ]
+        },
+        {
+          "name": "qtbase",
+          "host": true,
+          "default-features": false
+        },
+        {
+          "name": "qtmultimedia",
+          "default-features": false
+        },
+        {
+          "name": "qtmultimedia",
+          "platform": "linux",
+          "features": ["gstreamer"],
+          "default-features": false
+        },
+        "qtsvg"
+      ]
+    },
+    "qt5": {
+      "description": "Use Qt 5 for the frontend.",
+      "dependencies": [
+        {
+          "name": "qt5-base",
+          "default-features": false
+        },
+        {
+          "name": "qt5-base",
+          "host": true,
+          "default-features": false
+        },
+        "qt5-multimedia",
+        "qt5-svg"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## **melonDS — Shader/Filter UI Extension**

This PR adds a runtime shader filter system to melonDS, allowing users to apply visual filters (scalers, CRT effects, anti-aliasing, handheld LCD grids, etc.) directly from the View → Filters window without needing to edit config files manually.

 **Key Implementations:**
- **35 curated shader presets** from the [libretro slang-shaders](https://github.com/libretro/slang-shaders) collection, including xBRZ, HQx, Scale2x, Super-xBR, SMAA, FXAA, CRT EasyMode/Geom/Hyllian/Lottes, GameBoy DMG, LCD Grid, NTSC composite, and more
 - **Filter stacking** — combine multiple shaders (e.g. xBRZ upscale + CRT scanlines)
- **Adjustable parameters** — sliders for every shader parameter with extended ranges for experimentation
- **Persistent settings** — your filter selection and parameter tweaks are saved across sessions
- **No External Dependencies Required for End-Users:** Shaders are compiled at runtime via glslang and spirv-cross.

The slang-shaders submodule remains **pristine** — zero modifications to any shader source. All integration is in the C++ frontend layer.


**Architectural Notes & CI/CD Changes:**

- I kept modifications to the original core code to an absolute minimum. The major architectural addition is the inclusion of the glslang and spirv-cross libraries. These are the official Khronos compilers and the standard, high-performance method for reading and translating Slang shaders natively.
- CI/CD and Packaging: To ensure the res/slang-shaders directory is properly distributed to end-users out-of-the-box, I updated the GitHub Actions workflows. The pipeline now packages the executable alongside the res/ folder (bundled into a .zip for Windows/BSD, and natively injected into the .AppImage / .app directories for Linux/macOS).

_**Modified files (focused on GLSLANG/SPIRV-CROSS integration and packaging):**_

vcpkg.json
.github/workflows/build-bsd.yml
.github/workflows/build-macos.yml
.github/workflows/build-ubuntu.yml
.github/workflows/build-windows.yml
CMakeLists.txt
src/frontend/qt_sdl/CMakeLists.txt
src/frontend/qt_sdl/Config.cpp
src/frontend/qt_sdl/Screen.cpp
src/frontend/qt_sdl/Screen.h
src/frontend/qt_sdl/Window.cpp
src/frontend/qt_sdl/Window.h

_**Added files (Core shader implementation and UI):**_

.gitmodules
res/slang-shaders/
src/frontend/qt_sdl/FrontendShader.h
src/frontend/qt_sdl/ShaderConfigDialog.cpp
src/frontend/qt_sdl/ShaderConfigDialog.h
src/frontend/qt_sdl/ShaderManager.cpp
src/frontend/qt_sdl/ShaderManager.h
src/frontend/qt_sdl/ShaderParser.cpp
src/frontend/qt_sdl/ShaderParser.h
src/frontend/qt_sdl/SlangPreset.cpp
src/frontend/qt_sdl/SlangPreset.h


### Showcase:


<img width="308" height="303" alt="shader-menu-1" src="https://github.com/user-attachments/assets/dd3d179f-fbe1-4a87-b8f2-16e0b09105ab" />
<img width="706" height="548" alt="shader-menu-2" src="https://github.com/user-attachments/assets/e05788b9-6782-4e3e-94d3-55fa7d2b57fe" />
<img width="1840" height="1380" alt="nearest-default" src="https://github.com/user-attachments/assets/a0a13e48-6571-4e4f-8c33-0b059f680056" />
<img width="1840" height="1380" alt="adaptative-sharpen" src="https://github.com/user-attachments/assets/9c098ef8-8c53-4d49-9350-b69c46851579" />
<img width="1840" height="1380" alt="crt-hyllian" src="https://github.com/user-attachments/assets/d9d39830-7038-471f-8d16-449589d1faec" />
<img width="1840" height="1380" alt="nds-color" src="https://github.com/user-attachments/assets/231792cb-4bc8-4893-8af6-790f8332fc2c" />
<img width="1840" height="1380" alt="sabr" src="https://github.com/user-attachments/assets/c9ee00d7-880d-49cd-bba1-b839967ec5e9" />
<img width="1840" height="1380" alt="xbrz-6x" src="https://github.com/user-attachments/assets/808de6a8-7d52-424f-8364-45c265580279" />
<img width="1840" height="1380" alt="zfast-lcd" src="https://github.com/user-attachments/assets/7ec888b9-80b5-4cf6-a3b4-1d136e0fb180" />


