### PR TITLE
Add a homebrew slot-2 analog stick device for analog input hacks

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <cmath>
 #include "NDS.h"
 #include "GBACart.h"
 #include "CRC32.h"
@@ -63,6 +64,11 @@ void CartCommon::SetSaveMemory(const u8* savedata, u32 savelen)
 }
 
 int CartCommon::SetInput(int num, bool pressed)
+{
+    return -1;
+}
+
+int CartCommon::SetInput(int num, float value)
 {
     return -1;
 }
@@ -794,6 +800,75 @@ u8 CartGuitarGrip::SRAMRead(u32 addr)
         | (Platform::Addon_KeyDown(Platform::KeyGuitarGripBlue, UserData) ? 0x08 : 0));
 }
 
+CartAnalog::CartAnalog()
+    : CartCommon(Analog), X(0), Y(0)
+{
+}
+
+CartAnalog::~CartAnalog() = default;
+
+void CartAnalog::Reset()
+{
+    X = 0;
+    Y = 0;
+}
+
+void CartAnalog::DoSavestate(Savestate* file)
+{
+    CartCommon::DoSavestate(file);
+    file->Var32((u32*) &X);
+    file->Var32((u32*) &Y);
+}
+
+u16 CartAnalog::ROMRead(u32 addr) const
+{
+    addr &= 0x01FFFFFF;
+    u8 mode = (addr & 0xFF00) >> 8;
+    u8 val = addr & 0xFF;
+
+    if (mode == 0)
+    { // Common
+        switch (val)
+        {
+        case 0x08: return (s16) std::lround(X * 0x1000);
+        case 0x0A: return (s16) std::lround(Y * 0x1000);
+        default: return 0xFFFF;
+        }
+    }
+    else if (mode == 1)
+    { // Super Mario 64 DS analog hack
+        float tempX = X;
+        float tempY = Y;
+
+        float magnitude = std::hypot(X, Y);
+        float angle = std::atan2(X, Y);
+        if (magnitude > 1.0f)
+        {
+            tempX /= magnitude;
+            tempY /= magnitude;
+            magnitude = 1.0f;
+        }
+
+        switch (val)
+        {
+        case 0x00: return (s16) std::lround(magnitude * 4096.f);
+        case 0x02: return (s16) std::lround(tempX * 4096.f);
+        case 0x04: return (s16) std::lround(tempY * 4096.f);
+        case 0x06: return (s16) std::lround(angle * 10430.3783504704f);
+        default: return 0xFFFF;
+        }
+    }
+
+    return CartCommon::ROMRead(addr);
+}
+
+int CartAnalog::SetInput(int input, float value)
+{
+    if (input == Input_AnalogX) X = value;
+    if (input == Input_AnalogY) Y = value;
+    return -1;
+}
+
 GBACartSlot::GBACartSlot(melonDS::NDS& nds, std::unique_ptr<CartCommon>&& cart) noexcept : NDS(nds), Cart(std::move(cart))
 {
 }
@@ -933,6 +1008,8 @@ std::unique_ptr<CartCommon> LoadAddon(int type, void* userdata)
         break;
     case GBAAddon_GuitarGrip:
         cart = std::make_unique<CartGuitarGrip>(userdata);
+    case GBAAddon_Analog:
+        cart = std::make_unique<CartAnalog>();
         break;
     default:
         Log(LogLevel::Warn, "GBACart: !! invalid addon type %d\n", type);
@@ -985,6 +1062,13 @@ std::unique_ptr<CartCommon> GBACartSlot::EjectCart() noexcept
 int GBACartSlot::SetInput(int num, bool pressed) noexcept
 {
     if (Cart) return Cart->SetInput(num, pressed);
+
+    return -1;
+}
+
+int GBACartSlot::SetInput(int num, float value) noexcept
+{
+    if (Cart) return Cart->SetInput(num, value);
 
     return -1;
 }

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -36,6 +36,7 @@ enum CartType
     MotionPakHomebrew = 0x203,
     MotionPakRetail = 0x204,
     GuitarGrip = 0x205,
+    Analog = 0x206,
 };
 
 // See https://problemkaputt.de/gbatek.htm#gbacartridgeheader for details
@@ -71,6 +72,7 @@ public:
     virtual void DoSavestate(Savestate* file);
 
     virtual int SetInput(int num, bool pressed);
+    virtual int SetInput(int num, float value);
 
     virtual u16 ROMRead(u32 addr) const;
     virtual void ROMWrite(u32 addr, u16 val);
@@ -297,6 +299,28 @@ enum
     Input_GuitarGripRed,
     Input_GuitarGripYellow,
     Input_GuitarGripBlue,
+    Input_AnalogX,
+    Input_AnalogY,
+};
+
+// CartAnalog - Fake Slot-2 analog stick card used for ROM hacks
+class CartAnalog : public CartCommon
+{
+public:
+    CartAnalog();
+    ~CartAnalog() override;
+
+    void Reset() override;
+    void DoSavestate(Savestate* file) override;
+
+    // values should be -1.0..1.0
+    int SetInput(int num, float value) override;
+
+    u16 ROMRead(u32 addr) const override;
+
+private:
+    float X;
+    float Y;
 };
 
 class GBACartSlot
@@ -328,6 +352,7 @@ public:
 
     // TODO: make more flexible, support nonbinary inputs
     int SetInput(int num, bool pressed) noexcept;
+    int SetInput(int num, float value) noexcept;
 
     void SetOpenBusDecay(u16 val) noexcept { OpenBusDecay = val; }
 

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -350,7 +350,6 @@ public:
     /// or \c nullptr if the cart slot was empty.
     std::unique_ptr<CartCommon> EjectCart() noexcept;
 
-    // TODO: make more flexible, support nonbinary inputs
     int SetInput(int num, bool pressed) noexcept;
     int SetInput(int num, float value) noexcept;
 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -235,6 +235,7 @@ enum
     GBAAddon_MotionPakHomebrew = 6,
     GBAAddon_MotionPakRetail = 7,
     GBAAddon_GuitarGrip = 8,
+    GBAAddon_Analog = 9,
 };
 
 class SPU;

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -2171,6 +2171,8 @@ QString EmuInstance::gbaAddonName(int addon)
         return "Motion Pack (Retail)";
     case GBAAddon_GuitarGrip:
         return "Guitar Grip";
+    case GBAAddon_Analog:
+        return "Analog Input (Homebrew)";
     }
 
     return "???";

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -357,6 +357,9 @@ private:
     int hkKeyMapping[HK_MAX];
     int hkJoyMapping[HK_MAX];
 
+    float analogX;
+    float analogY;
+
     int joystickID;
     SDL_Joystick* joystick;
     SDL_GameController* controller;

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -448,12 +448,8 @@ void EmuInstance::inputProcess()
         // TODO: actual mapping for this
         analogX = ((float) SDL_JoystickGetAxis(joystick, 0)) / 32768.f;
         analogY = ((float) SDL_JoystickGetAxis(joystick, 1)) / 32768.f;
-        float magnitude = std::hypot(analogX, analogY);
-        if (magnitude < 0.05)
-        {
-            analogX = 0;
-            analogY = 0;
-        }
+        if (std::fabs(analogX) < 0.1) analogX = 0;
+        if (std::fabs(analogY) < 0.1) analogY = 0;
     }
 
     inputMask = keyInputMask & joyInputMask;

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -95,6 +95,9 @@ void EmuInstance::inputInit()
     touchX = 0;
     touchY = 0;
 
+    analogX = 0.f;
+    analogY = 0.f;
+
     joystick = nullptr;
     controller = nullptr;
     hasRumble = false;
@@ -441,6 +444,16 @@ void EmuInstance::inputProcess()
         for (int i = 0; i < 12; i++)
             if (joystickButtonDown(joyMapping[i]))
                 joyInputMask &= ~(1 << i);
+
+        // TODO: actual mapping for this
+        analogX = ((float) SDL_JoystickGetAxis(joystick, 0)) / 32768.f;
+        analogY = ((float) SDL_JoystickGetAxis(joystick, 1)) / 32768.f;
+        float magnitude = std::hypot(analogX, analogY);
+        if (magnitude < 0.05)
+        {
+            analogX = 0;
+            analogY = 0;
+        }
     }
 
     inputMask = keyInputMask & joyInputMask;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -189,6 +189,9 @@ void EmuThread::run()
                 }
             }
 
+            emuInstance->nds->GBACartSlot.SetInput(GBACart::Input_AnalogX, emuInstance->analogX);
+            emuInstance->nds->GBACartSlot.SetInput(GBACart::Input_AnalogY, emuInstance->analogY);
+
             if (emuInstance->nds->ConsoleType == 1)
             {
                 DSi* dsi = static_cast<DSi*>(emuInstance->nds);

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -289,6 +289,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                     GBAAddon_MotionPakHomebrew,
                     GBAAddon_MotionPakRetail,
                     GBAAddon_GuitarGrip,
+                    GBAAddon_Analog,
                     -1
                 };
 


### PR DESCRIPTION
This adds the homebrew slot-2 analog input device used by one of the SM64DS analog hacks to melonDS. Previously, only a now-outdated fork of DeSmuME supported this.

We had discussed that this would likely be better to do in a different way, but since it seems to be a quite popular request and this implementation already works well, I'm now going to open this as an actual PR anyway.

Currently there is no way to set the mappings for this in the UI, it simply always uses the left analog stick of the controller which I figure should be good enough for a fairly niche feature like this, but I can add proper mapping if needed.