### PR TITLE
fix vcount writing causing hangs

### DIFF
--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1386,7 +1386,7 @@ void GPU::SetVCount(u16 val, u16 mask) noexcept
 
     u16 nextvc = (NextVCount & ~mask) | (val & mask);
 
-    GPU3D.AbortFrame |= NextVCount != nextvc;
+    GPU3D.AbortFrame = true; // CHECKME: this probably shouldn't be done if the vcount written is the same as the vcount of the next scanline
     NextVCount = nextvc;
     VCountOverride = true;
 }

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1384,10 +1384,9 @@ void GPU::SetVCount(u16 val, u16 mask) noexcept
     // 3D engine seems to give up on the current frame in that situation, repeating the last two scanlines
     // TODO: also check the various DMA types that can be involved
 
-    u16 nextvc = (NextVCount & ~mask) | (val & mask);
+    NextVCount = (NextVCount & ~mask) | (val & mask);
 
     GPU3D.AbortFrame = true; // CHECKME: this probably shouldn't be done if the vcount written is the same as the vcount of the next scanline
-    NextVCount = nextvc;
     VCountOverride = true;
 }
 


### PR DESCRIPTION
fixes https://github.com/melonDS-emu/melonDS/issues/2707
not 100% sure what the original code here was intended to do but it caused issues.
was going to bundle in a bonus fix of giving the arm7 and arm9 their own internal vcount reg to better match hw behavior, but i decided against since im not 100% confident in my testing on how that behaves when both cpus write on the same scanline.