### PR TITLE
Reject malformed savestate container metadata

### DIFF
--- a/src/FIFO.h
+++ b/src/FIFO.h
@@ -45,6 +45,12 @@ public:
         file->Var32(&WritePos);
 
         file->VarArray(Entries, sizeof(T)*NumEntries);
+
+        if (!file->Saving && !file->Error &&
+            (NumOccupied > NumEntries || ReadPos >= NumEntries || WritePos >= NumEntries))
+        {
+            file->Error = true;
+        }
     }
 
 
@@ -136,6 +142,12 @@ public:
         file->Var32(&WritePos);
 
         file->VarArray(Entries, sizeof(T)*NumEntries);
+
+        if (!file->Saving && !file->Error &&
+            (NumOccupied > NumEntries || ReadPos >= NumEntries || WritePos >= NumEntries))
+        {
+            file->Error = true;
+        }
     }
 
 
@@ -213,6 +225,12 @@ public:
         file->Var32(&WritePos);
 
         file->VarArray(Buffer, Size);
+
+        if (!file->Saving && !file->Error &&
+            (NumOccupied > Size || ReadPos >= Size || WritePos >= Size))
+        {
+            file->Error = true;
+        }
     }
 
 

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -367,6 +367,12 @@ u32 Savestate::FindSection(const char* magic) const
     for (u32 offset = 0x10; offset < buffer_length;)
     { // Until we've found the desired section...
 
+        if (buffer_length - offset < 16)
+        {
+            Log(LogLevel::Error, "savestate: truncated section header\n");
+            return NO_SECTION;
+        }
+
         // Get this section's magic number
         char read_magic[4] = {0};
         memcpy(read_magic, buffer + offset, sizeof(read_magic));
@@ -378,15 +384,15 @@ u32 Savestate::FindSection(const char* magic) const
 
         // Haven't found our section yet. Let's move on to the next one.
 
-        u32 section_length_offset = offset + sizeof(read_magic);
-        if (section_length_offset >= buffer_length)
-        { // If trying to read the section length would take us past the file's end...
-            break;
-        }
-
         // First we need to find out how big this section is...
         u32 section_length = 0;
-        memcpy(&section_length, buffer + section_length_offset, sizeof(section_length));
+        memcpy(&section_length, buffer + offset + sizeof(read_magic), sizeof(section_length));
+
+        if (section_length < 16 || section_length > buffer_length - offset)
+        {
+            Log(LogLevel::Error, "savestate: invalid section length %u\n", section_length);
+            return NO_SECTION;
+        }
 
         // ...then skip it. (The section length includes the 16-byte header.)
         offset += section_length;


### PR DESCRIPTION
Savestate::FindSection previously trusted each on-disk section length when
advancing through the file. A zero-length record prevented the cursor from
advancing, causing state loading to loop indefinitely.

FIFO, DynamicFIFO, and RingBuffer also restored their count and cursor fields
without validating them against the container capacity. A malformed save state
could therefore leave a queue with invalid indices that were later used for
array access.

Reject truncated and invalid section records, and fail savestate loading when
restored FIFO metadata is outside the associated container bounds.