### PR TITLE
Reject undersized GBA ROM images

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -868,6 +868,12 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
         return nullptr;
     }
 
+    if (romlen < sizeof(GBAHeader))
+    {
+        Log(LogLevel::Error, "GBACart: ROM is too small\n");
+        return nullptr;
+    }
+
     auto [cartrom, cartromsize] = PadToPowerOf2(std::move(romdata), romlen);
 
     char gamecode[5] = { '\0' };


### PR DESCRIPTION
GBACart::ParseROM accepts any non-empty image, then immediately reads the
game-code field at offset 0xAC to detect solar-sensor titles. Images shorter
than the GBA header therefore reach a read beyond the allocated ROM buffer.

Require the input to contain a complete GBA header before padding or inspecting
header fields. This keeps malformed and truncated images out of the parser.