### PR TITLE
Validate DS ROM binary ranges without overflow

### DIFF
--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -366,13 +366,16 @@ bool ValidateROM(u32 romlen, NDSHeader& header)
 {
     // basic sanity checks to ensure we have a workable ROM file
 
-    if (header.ARM9ROMOffset < 0x200)
+    if (header.ARM9ROMOffset < 0x200 || (header.ARM9Size & 3) ||
+        header.ARM9ROMOffset >= romlen ||
+        header.ARM9Size > romlen - header.ARM9ROMOffset)
         return false;
-    if ((header.ARM9ROMOffset + header.ARM9Size) > romlen)
+    if (header.ARM9ROMOffset >= 0x4000 && header.ARM9ROMOffset < 0x8000 &&
+        header.ARM9Size < 0x800)
         return false;
-    if (header.ARM7ROMOffset < 0x200)
-        return false;
-    if ((header.ARM7ROMOffset + header.ARM7Size) > romlen)
+    if (header.ARM7ROMOffset < 0x200 || (header.ARM7Size & 3) ||
+        header.ARM7ROMOffset >= romlen ||
+        header.ARM7Size > romlen - header.ARM7ROMOffset)
         return false;
 
     return true;


### PR DESCRIPTION
NDSCart::ValidateROM checked ARM9 and ARM7 binary ranges by adding the
header-provided offset and size before comparing the result with the ROM
length. A wrapped addition could pass that check even though the binary range
was outside the ROM.

NDS::Reset later loads these binaries in 32-bit words, so non-word-aligned
sizes could also make the final load extend beyond an accepted image. The
special ARM9 secure-area path similarly expects a complete 0x800-byte region.

Validate ranges by subtraction after checking the offset, require word-aligned
binary sizes, and reject incomplete secure areas before the load paths run.