### PR TITLE
NocashPrint: Fix can't print from ITCM/DTCM

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1555,14 +1555,14 @@ void NDS::NocashPrint(u32 ncpu, u32 addr, bool appendNewline)
     // addr: debug string
 
     ARM* cpu = ncpu ? (ARM*)&ARM7 : (ARM*)&ARM9;
-    u8 (NDS::*readfn)(u32) = ncpu ? &NDS::ARM7Read8 : &NDS::ARM9Read8;
 
     char output[1024];
     int ptr = 0;
 
     for (int i = 0; i < 120 && ptr < 1023; )
     {
-        char ch = (this->*readfn)(addr++);
+        u32 ch = 0;
+        cpu->DataRead8(addr++, &ch);
         i++;
 
         if (ch == '%')
@@ -1570,7 +1570,8 @@ void NDS::NocashPrint(u32 ncpu, u32 addr, bool appendNewline)
             char cmd[16]; int j;
             for (j = 0; j < 15; )
             {
-                char ch2 = (this->*readfn)(addr++);
+                u32 ch2 = 0;
+                cpu->DataRead8(addr++, &ch2);
                 i++;
                 if (i >= 120) break;
                 if (ch2 == '%') break;


### PR DESCRIPTION
No$gba defines a printing mechanism using pseudo IO ports, which melonDS also supports. In No$gba, printing a string in TCM works fine, but in melonDS it doesn't (yields an unknown arm9 read warning).

This happens because melon effectively emulates the read as a bus read, calling NDS::ArmXRead8 which skips the TCM check (which is implemented in the ARM module). This PR changes it to a read via CPU, which defers to a bus read if the address is not in TCM.

This does have a side effect of updating DataCycles in the ARM instance, but I don't think this should be a problem here? It will also cause a data abort if the address being printed is not mapped , but I don't think that's a use case. Debug printing is a development feature anyway.

Reference: https://problemkaputt.de/gbatek.htm#dsdebugregistersemulatordevkits