### PR TITLE
fix implementation of sqrt in freebios

### DIFF
--- a/freebios/src/bios_common.s
+++ b/freebios/src/bios_common.s
@@ -541,9 +541,9 @@ swi_sqrt:
  0:
   orr root_check, square_index, root
   cmp remainder, root_check
-  subge remainder, remainder, root_check
+  subhs remainder, remainder, root_check
   mov root, root, lsr #1
-  orrge root, root, square_index
+  orrhs root, root, square_index
   movs square_index, square_index, lsr #2
   bne 0b
 


### PR DESCRIPTION
The sqrt SWI takes an unsigned integer, but subge/orrge perform signed comparisons. This means for any number >= 0x80000000, we perform incorrect arithmetic and the root gets forced to 0. This switches the instructions to perform unsigned comparisons.

An example of this bug can be observed in Rockman.EXE Operate Shooting Star, where if Rockman is on the furthest row from a Beetank, the Beetank's projectile will be aimed at itself rather than Rockman.

Before: 
<img width="1648" height="716" alt="image" src="https://github.com/user-attachments/assets/14f18e70-4c59-4b49-9873-013ab01ad36f" />

After:
<img width="1648" height="716" alt="image" src="https://github.com/user-attachments/assets/f3f004d5-7512-4887-a58d-c6ea851e2287" />
<img width="1648" height="716" alt="image" src="https://github.com/user-attachments/assets/427917cf-ba51-49d7-b6cc-ea80571747f1" />
