### PR TITLE
Add ability to take native screenshots (when using Software Renderer)

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -2270,3 +2270,58 @@ void EmuInstance::animatedROMIcon(const u8 (&data)[8][512], const u16 (&palette)
             animatedSequenceRef.push_back(i);
     }
 }
+
+bool EmuInstance::takeScreenshot(){
+    void* topbuf; void* bottombuf;
+    if(getNDS()->GPU.GetFramebuffers(&topbuf, &bottombuf))
+    {
+        size_t width = 256;
+        size_t height = 192;
+
+        // write top and bottom buffers into one big buffer and convert bgra32 to argb32
+        // new buffer needs to be uchar because qt wants to
+        uchar* newbuf = new uchar[width * height * 2 * 4];
+
+        u32 newIndex = 0;
+        for(size_t i = 0; i < width * height; i++)
+        {
+            newbuf[newIndex++] = (((u32*)topbuf)[i] & 0x000000FF);
+            newbuf[newIndex++] = (((u32*)topbuf)[i] & 0x0000FF00) >> 8;
+            newbuf[newIndex++] = (((u32*)topbuf)[i] & 0x00FF0000) >> 16;
+            newbuf[newIndex++] = (((u32*)topbuf)[i] & 0xFF000000) >> 24;
+        }
+        for(size_t i = 0; i < width * height; i++)
+        { 
+            newbuf[newIndex++] = (((u32*)bottombuf)[i] & 0x000000FF);
+            newbuf[newIndex++] = (((u32*)bottombuf)[i] & 0x0000FF00) >> 8;
+            newbuf[newIndex++] = (((u32*)bottombuf)[i] & 0x00FF0000) >> 16;
+            newbuf[newIndex++] = (((u32*)bottombuf)[i] & 0xFF000000) >> 24;
+        }
+        
+        QImage img = QImage(newbuf, width, height * 2, QImage::Format_ARGB32);
+        
+        auto now = std::chrono::system_clock::now();
+        auto duration = now.time_since_epoch();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        
+        std::string fileName = "melonDS-" + std::to_string(ms);
+        std::string filePath = getAssetPath(false, getLocalConfig().GetString("ScreenshotPath"), ".png", fileName);
+        
+        if(!img.save(QString::fromStdString(filePath), "PNG"))
+        {
+            Log(LogLevel::Debug, "Failed to take screenshot\n");
+            osdAddMessage(0xFFA0A0, "Failed to take screenshot");
+            return false;
+        }
+        
+        osdAddMessage(0, "Screenshot saved as %s", filePath.c_str());
+        Log(LogLevel::Info, "Screenshot saved as %s\n", filePath.c_str());
+    }
+    else
+    {
+        Log(LogLevel::Warn, "Aborting screenshot because not using Software Renderer\n");
+        osdAddMessage(0, "Screenshot can only be taken using software renderer");
+        return false;
+    }
+    return true;
+}

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -166,6 +166,8 @@ public:
     // mic start/stop control from core
     void micStart();
     void micStop();
+    
+    bool takeScreenshot();
     int micReadInput(melonDS::s16* data, int maxlength);
 
     QMutex renderLock;

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -56,6 +56,7 @@ enum
     HK_GuitarGripRed,
     HK_GuitarGripYellow,
     HK_GuitarGripBlue,
+    HK_Screenshot,
     HK_MAX
 };
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -67,7 +67,8 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
     "HK_GuitarGripGreen",
     "HK_GuitarGripRed",
     "HK_GuitarGripYellow",
-    "HK_GuitarGripBlue"
+    "HK_GuitarGripBlue",
+    "HK_Screenshot"
 };
 
 std::shared_ptr<SDL_mutex> EmuInstance::joyMutexGlobal = nullptr;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -496,26 +496,7 @@ void EmuThread::handleMessages()
             break;
 
         case msg_EmuScreenshot:
-            void* topbuf; void* bottombuf;
-            if(emuInstance->getNDS()->GPU.GetFramebuffers(&topbuf, &bottombuf))
-            {
-                FILE *file;
-                file = fopen("/home/cecilia/melonTest/top", "wb");
-                fwrite(topbuf, 4, 256 * 192, file);
-                fclose(file);
-
-                file = fopen("/home/cecilia/melonTest/bottom", "wb");
-                fwrite(bottombuf, 4, 256 * 192, file);
-                fclose(file);
-            }
-            else{
-                Log(LogLevel::Debug, "meowww ogl\n");
-
-                FILE *file;
-                file = fopen("/home/cecilia/melonTest/top", "rb");
-                fwrite(topbuf, sizeof(topbuf), 1, file);
-                fclose(file);
-            }
+            emuInstance->takeScreenshot();
             break;
 
         case msg_EmuPause:
@@ -781,10 +762,10 @@ void EmuThread::emuReset()
 
 void EmuThread::emuTakeScreenshot()
 {
-    Log(LogLevel::Debug, "Taking screenshot\n");
     if (!emuActive){
         return;
     }
+    Log(LogLevel::Info, "Taking screenshot\n");
     sendMessage(msg_EmuScreenshot);
     waitMessage();
 }

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -159,6 +159,8 @@ void EmuThread::run()
 
         if (emuInstance->hotkeyPressed(HK_FrameLimitToggle)) emit windowLimitFPSChange();
 
+        if (emuInstance->hotkeyPressed(HK_Screenshot)) emuTakeScreenshot();
+
         if (emuInstance->hotkeyPressed(HK_Pause)) emuTogglePause();
         if (emuInstance->hotkeyPressed(HK_Reset)) emuReset();
         if (emuInstance->hotkeyPressed(HK_FrameStep)) emuFrameStep();
@@ -493,6 +495,29 @@ void EmuThread::handleMessages()
             emit windowEmuStart();
             break;
 
+        case msg_EmuScreenshot:
+            void* topbuf; void* bottombuf;
+            if(emuInstance->getNDS()->GPU.GetFramebuffers(&topbuf, &bottombuf))
+            {
+                FILE *file;
+                file = fopen("/home/cecilia/melonTest/top", "wb");
+                fwrite(topbuf, 4, 256 * 192, file);
+                fclose(file);
+
+                file = fopen("/home/cecilia/melonTest/bottom", "wb");
+                fwrite(bottombuf, 4, 256 * 192, file);
+                fclose(file);
+            }
+            else{
+                Log(LogLevel::Debug, "meowww ogl\n");
+
+                FILE *file;
+                file = fopen("/home/cecilia/melonTest/top", "rb");
+                fwrite(topbuf, sizeof(topbuf), 1, file);
+                fclose(file);
+            }
+            break;
+
         case msg_EmuPause:
             emuPauseStack++;
             if (emuPauseStack > emuPauseStackPauseThreshold) break;
@@ -751,6 +776,16 @@ void EmuThread::emuFrameStep()
 void EmuThread::emuReset()
 {
     sendMessage(msg_EmuReset);
+    waitMessage();
+}
+
+void EmuThread::emuTakeScreenshot()
+{
+    Log(LogLevel::Debug, "Taking screenshot\n");
+    if (!emuActive){
+        return;
+    }
+    sendMessage(msg_EmuScreenshot);
     waitMessage();
 }
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -84,6 +84,7 @@ public:
         msg_ImportSavefile,
 
         msg_EnableCheats,
+        msg_EmuScreenshot,
     };
 
     struct Message
@@ -112,6 +113,7 @@ public:
     void emuExit();
     void emuFrameStep();
     void emuReset();
+    void emuTakeScreenshot();
 
     int bootROM(const QStringList& filename, QString& errorstr);
     int bootFirmware(QString& errorstr);

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -68,7 +68,8 @@ static constexpr std::initializer_list<int> hk_general =
     HK_PowerButton,
     HK_VolumeUp,
     HK_VolumeDown,
-    HK_AudioMuteToggle
+    HK_AudioMuteToggle,
+    HK_Screenshot
 };
 
 static constexpr std::initializer_list<const char*> hk_general_labels =
@@ -89,7 +90,8 @@ static constexpr std::initializer_list<const char*> hk_general_labels =
     "DSi Power button",
     "DSi Volume up",
     "DSi Volume down",
-    "Toggle audio mute"
+    "Toggle audio mute",
+    "Screenshot"
 };
 
 static_assert(hk_general.size() == hk_general_labels.size());

--- a/src/frontend/qt_sdl/PathSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/PathSettingsDialog.cpp
@@ -49,6 +49,7 @@ PathSettingsDialog::PathSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     ui->txtSaveFilePath->setText(cfg.GetQString("SaveFilePath"));
     ui->txtSavestatePath->setText(cfg.GetQString("SavestatePath"));
     ui->txtCheatFilePath->setText(cfg.GetQString("CheatFilePath"));
+    ui->txtScreenshotPath->setText(cfg.GetQString("ScreenshotPath"));
 
     int inst = emuInstance->getInstanceID();
     if (inst > 0)
@@ -112,6 +113,7 @@ void PathSettingsDialog::done(int r)
             cfg.SetQString("SaveFilePath", ui->txtSaveFilePath->text());
             cfg.SetQString("SavestatePath", ui->txtSavestatePath->text());
             cfg.SetQString("CheatFilePath", ui->txtCheatFilePath->text());
+            cfg.SetQString("ScreenshotPath", ui->txtScreenshotPath->text());
 
             Config::Save();
 
@@ -173,4 +175,21 @@ void PathSettingsDialog::on_btnCheatFileBrowse_clicked()
     }
 
     ui->txtCheatFilePath->setText(dir);
+}
+
+void PathSettingsDialog::on_btnScreenshotBrowse_clicked()
+{
+    QString dir = QFileDialog::getExistingDirectory(this,
+                                                     "Select screenshot files path...",
+                                                     emuDirectory);
+
+    if (dir.isEmpty()) return;
+    
+    if (!QTemporaryFile(dir).open())
+    {
+        QMessageBox::critical(this, "melonDS", errordialog);
+        return;
+    }
+
+    ui->txtScreenshotPath->setText(dir);
 }

--- a/src/frontend/qt_sdl/PathSettingsDialog.h
+++ b/src/frontend/qt_sdl/PathSettingsDialog.h
@@ -61,6 +61,7 @@ private slots:
     void on_btnSaveFileBrowse_clicked();
     void on_btnSavestateBrowse_clicked();
     void on_btnCheatFileBrowse_clicked();
+    void on_btnScreenshotBrowse_clicked();
 
 private:
     Ui::PathSettingsDialog* ui;

--- a/src/frontend/qt_sdl/PathSettingsDialog.ui
+++ b/src/frontend/qt_sdl/PathSettingsDialog.ui
@@ -35,7 +35,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="6" column="0" colspan="3">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string/>
@@ -63,7 +63,28 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+    <item row="4" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Screenshot path:</string>
+     </property>
+    </widget>
+   </item>
+    <item row="4" column="1">
+    <widget class="QLineEdit" name="txtScreenshotPath">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QPushButton" name="btnScreenshotBrowse">
+     <property name="text">
+      <string>Browse...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -87,7 +108,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
+   <item row="5" column="0" colspan="3">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Leave a path blank to use the current ROM's path.</string>
@@ -117,6 +138,8 @@
   <tabstop>btnSavestateBrowse</tabstop>
   <tabstop>txtCheatFilePath</tabstop>
   <tabstop>btnCheatFileBrowse</tabstop>
+  <tabstop>txtScreenshotPath</tabstop>
+  <tabstop>btnScreenshotBrowse</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
As described in #1552 / #2454 (and maybe more, did not to an elaborate search), this adds the ability to take native resolution screenshots (*when using Software Renderer).
This is done by taking both buffers, stacking them on top of each other, converting the data from BGRA32 to ARGB32 and finally saving the new buffer as a png file to disk.
As I'm not that familiar with the codebase I'm not that sure if this (`EmuInstance`/`EmuThread`) is the right place to implement this so feel free suggest changes.
Sadly I was not able to figure out how to make it work for the OpenGL Renderer aswell, so this is only supporting the Software Renderer for now.

(No AI was used for this but as I'm not that well-versed in C++, the code might still be suboptimal so please feel free to point out any areas that could be improved)