### PR TITLE
always start with slot1 powered on on dsi as well

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -194,7 +194,7 @@ void DSi::Reset()
     SCFG_Clock7 = 0x0187;
     SCFG_EXT[0] = 0x8307F100;
     SCFG_EXT[1] = 0x93FFFB06;
-    SCFG_MC = 0x0010 | (NDSCartSlot.CartInserted() ? 0 : (1<<0));
+    SCFG_MC = 0x0010 | (NDSCartSlot.CartInserted() ? (1<<3) : (1<<0));
     SCFG_CartInsertDelay = 0xFFFF;
     SCFG_CartPowerOffDelay = 0xFFFF;
     SCFG_RST = 0;

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -216,12 +216,7 @@ void NDSCartSlot::Reset() noexcept
 {
     SetLogicalNum(Num);
 
-    // on DS, the cart interface is always powered on
-    // on DSi, start powered off - SCFG_MC is used to power the interface up/down
-    if (NDS.ConsoleType == 1)
-        PowerState = 0;
-    else
-        PowerState = 2;
+	PowerState = 2;
 
     for (auto& inter : Interfaces)
         inter.Reset();


### PR DESCRIPTION
Unlike what the comment says, this seems to be the case on dsi as well.
We can't verify fully from a clean hardware state, but without this change, with full firmware boot, gcdboot is no longer possible to perform as the bootrom isn't enabling the slot explicitly yet it expects to be able to perform card reads on the arm7.
Likewise the bootrom doesn't touch that register when booting a stage2, so in that case too the slot should stay powered.